### PR TITLE
added travis badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pkgnet
 
-[![Build Status](https://travis-ci.org/UptakeOpenSource/travis.svg?branch=master)](https://travis-ci.org/UptakeOpenSource/travis)
+[![Build Status](https://travis-ci.org/UptakeOpenSource/pkgnet.svg?branch=master)](https://travis-ci.org/UptakeOpenSource/pkgnet)
 
 **WARNING: This package is still under construction. It's API can and will change. Please contribute to the conversation about its future by submitting issues and pull requests, or by contacting the package maintainer (see the DESCRIPTION file) directly.**
 


### PR DESCRIPTION
I did this wrong in my previous "travis badge" PR. This is correct