### PR TITLE
Feature/coverage by node

### DIFF
--- a/R/AbstractPackageReporter.R
+++ b/R/AbstractPackageReporter.R
@@ -56,13 +56,23 @@ AbstractPackageReporter <- R6::R6Class(
         set_package = function(packageName, packagePath = NULL) {
             
             private$packageName <- packageName
-            private$packagePath <- packagePath
+            
+            if (dir.exists(packagePath)) {
+              private$packagePath <- packagePath
+            } else {
+              stop(paste0("Package directory does not exist: ", packagePath))
+            }
+            
             
             return(invisible(NULL))
         },
         
         get_package = function(){
             return(private$packageName)
+        },
+        
+        get_package_path = function(){
+          return(private$packagePath)
         },
         
         get_report =  function() {

--- a/R/AbstractPackageReporter.R
+++ b/R/AbstractPackageReporter.R
@@ -57,10 +57,12 @@ AbstractPackageReporter <- R6::R6Class(
             
             private$packageName <- packageName
             
-            if (dir.exists(packagePath)) {
-              private$packagePath <- packagePath
-            } else {
-              stop(paste0("Package directory does not exist: ", packagePath))
+            if (exists("packagePath") && !is.null(packagePath)) {
+              if (dir.exists(packagePath)) {
+                private$packagePath <- packagePath
+              } else {
+                log_fatal(paste0("Package directory does not exist: ", packagePath))
+              }
             }
             
             

--- a/R/CreatePackageReport.R
+++ b/R/CreatePackageReport.R
@@ -1,9 +1,11 @@
-#' @title Creates a 
+#' @title Surface the internal and external dependecies of an R package.
 #' @name CreatePackageReport
-#' @description Obtain Ratio of Coverage For Each Function Within A Package
+#' @description Surface the internal and external dependecies of an R package. 
 #' @author B. Burns
 #' @param packageName name of a package
 #' @param packageReporters a list of package reporters
+#' @param packagePath (optional) the path to the package repository.  
+#' If given, coverage will be calculated for each function.
 #' @importFrom assertthat assert_that is.string
 #' @importFrom covr package_coverage tally_coverage
 #' @importFrom data.table as.data.table setnames
@@ -11,7 +13,8 @@
 #' @return A list of instantiated packageReporters the user can then interact with
 #' @export
 CreatePackageReport <- function(packageName
-                                , packageReporters = DefaultReporters()) {
+                                , packageReporters = DefaultReporters()
+                                , packagePath = NULL) {
     
     # Input checks
     assertthat::assert_that(assertthat::is.string(packageName)
@@ -34,7 +37,7 @@ CreatePackageReport <- function(packageName
     # Make them plots
     for (reporter in packageReporters){
         log_info("Running Package Reporter",class(reporter)[1])
-        reporter$set_package(packageName)
+        reporter$set_package(packageName, packagePath)
         
         reporter$calculate_metrics()
         # TODO: replace plot_network() with render_report() which is then rendered into a parent report.

--- a/R/PackageFunctionReporter.R
+++ b/R/PackageFunctionReporter.R
@@ -97,6 +97,20 @@ PackageFunctionReporter <- R6::R6Class(
         # TODO [patrick.bouer@uptake.com]: Implement packageTestCoverage metrics
         package_test_coverage = function(){
             return(invisible(NULL))
+          # Given private$nodes & package path
+          # result: update nodes table OR self$network measures?
+          
+          repoPath <- file.path(self$get_package_path())
+          
+          futile.logger::flog.info(msg = "Calculating package coverage...")
+          pkgCov <- covr::package_coverage(path = repoPath)
+          pkgCov <- data.table::as.data.table(pkgCov)
+          pkgCov <- pkgCov[, list(coverage = sum(value > 0)/.N)
+                           , by = list(node = functions)]
+          
+          # Update Network Measures active binding in parent
+          
+          
             
             # log_info('Checking package coverage...')
             # packageObj <- .UpdateNodes(nodes

--- a/R/PackageFunctionReporter.R
+++ b/R/PackageFunctionReporter.R
@@ -48,11 +48,12 @@ PackageFunctionReporter <- R6::R6Class(
             
             private$edges <- self$extract_network(...)
             private$nodes <- data.table::data.table(node = unique(c(private$edges[,SOURCE],private$edges[,TARGET])))
+            private$pkgGraph <- private$make_graph_object(private$edges, private$nodes)
             
             if (!is.null(private$packagePath)){
-                private$package_test_coverage()
+              private$package_test_coverage()
             }
-            private$pkgGraph <- private$make_graph_object(private$edges, private$nodes)
+            
             self$calculate_network_measures()
             
             return(invisible(NULL))
@@ -96,21 +97,25 @@ PackageFunctionReporter <- R6::R6Class(
         
         # TODO [patrick.bouer@uptake.com]: Implement packageTestCoverage metrics
         package_test_coverage = function(){
-            return(invisible(NULL))
           # Given private$nodes & package path
-          # result: update nodes table OR self$network measures?
+          # result: update nodes table 
           
           repoPath <- file.path(self$get_package_path())
           
-          futile.logger::flog.info(msg = "Calculating package coverage...")
+          log_info(msg = "Calculating package coverage...")
           pkgCov <- covr::package_coverage(path = repoPath)
           pkgCov <- data.table::as.data.table(pkgCov)
           pkgCov <- pkgCov[, list(coverage = sum(value > 0)/.N)
                            , by = list(node = functions)]
           
-          # Update Network Measures active binding in parent
+          # Update Node with Coverage Info
+          private$nodes <- merge(x = private$nodes
+                                 , y = pkgCov
+                                 , by = "node"
+                                 , all.x = TRUE)
           
-          
+          log_info(msg = "Done calculating package coverage...")
+          return(invisible(NULL))
             
             # log_info('Checking package coverage...')
             # packageObj <- .UpdateNodes(nodes

--- a/man/CreatePackageReport.Rd
+++ b/man/CreatePackageReport.Rd
@@ -2,21 +2,26 @@
 % Please edit documentation in R/CreatePackageReport.R
 \name{CreatePackageReport}
 \alias{CreatePackageReport}
-\title{Creates a}
+\title{Surface the internal and external dependecies of an R package.}
 \usage{
-CreatePackageReport(packageName, packageReporters = DefaultReporters())
+CreatePackageReport(packageName, packageReporters = DefaultReporters(),
+  packagePath = NULL)
 }
 \arguments{
 \item{packageName}{name of a package}
 
 \item{packageReporters}{a list of package reporters}
+
+\item{packagePath}{(optional) the path to the package repository.
+If given, coverage will be calculated for each function.}
 }
 \value{
 A list of instantiated packageReporters the user can then interact with
 }
 \description{
-Obtain Ratio of Coverage For Each Function Within A Package
+Surface the internal and external dependecies of an R package.
 }
 \author{
 B. Burns
 }
+


### PR DESCRIPTION
This uses `covr` to calculate coverage by function and add the coverage ratios to the nodes of `PackageFunctionReporter` object.  Coverage is only calculated with a package path is given.  This code checks that a valid path is given. 