### PR TITLE
Feature/dynamic node coloring

### DIFF
--- a/R/AbstractGraphReporter.R
+++ b/R/AbstractGraphReporter.R
@@ -179,11 +179,11 @@ AbstractGraphReporter <- R6::R6Class(
             self$set_graph_layout()
             
             # format for plot
-            plotDTnodes <- copy(private$nodes) # Don't modify original
+            plotDTnodes <- data.table::copy(private$nodes) # Don't modify original
             plotDTnodes[, id := node]
             plotDTnodes[, label := id]
             
-            plotDTedges <- copy(private$edges) # Don't modify original
+            plotDTedges <- data.table::copy(private$edges) # Don't modify original
             plotDTedges[, from := SOURCE]
             plotDTedges[, to := TARGET]
             plotDTedges[, color := '#848484'] # TODO Make edge formatting flexible too
@@ -220,7 +220,12 @@ AbstractGraphReporter <- R6::R6Class(
                 plotDTnodes[, color := newPallete(get(colorFieldName))]
                 
               } else {
-                log_fatal("A character, factor, or numeric field can be used to color nodes.")
+                log_fatal(sprintf(paste0("A character, factor, or numeric field can be used to color nodes. "
+                                         , "Field %s is of type %s.")
+                                  , colorFieldName
+                                  , typeof(colorFieldValues)
+                                  )
+                          )
                 
               } # end non-default color field
               
@@ -235,7 +240,7 @@ AbstractGraphReporter <- R6::R6Class(
               visNetwork::visOptions(highlightNearest = list(enabled = TRUE
                                                              , degree = nrow(plotDTnodes) #guarantee full path
                                                              , algorithm = "hierarchical")) 
-            log_info("Done creating plot...")
+            log_info("Done creating plot.")
             
             print(g) # to be removed once we have an HTML report function
             return(g)

--- a/R/AbstractGraphReporter.R
+++ b/R/AbstractGraphReporter.R
@@ -309,7 +309,7 @@ AbstractGraphReporter <- R6::R6Class(
         nodes = NULL,
         pkgGraph = NULL,
         plotNodeColorScheme = list(field = NULL
-                                 , pallete = 'green' #'#97C2FC'
+                                 , pallete = '#97C2FC'
                                  ),
         
         # Create a "cache" to be used when evaluating active bindings


### PR DESCRIPTION
Addressing issue #9 , this edit will allow network plots to have nodes colored by numeric, factor, and character fields available in `private$nodes`.   Therefore, any new process that updates the nodes table with a new metric, such as `package_test_coverage`, can set the plot to be colored by that newly added metric.   Similarly, we could color by other categories like source script name, object class, etc.

Example: 
This will produce two plots: 
1. a default plot
2. a plot colored by the "node" field. 

```t <- PackageFunctionReporter$new()
t$set_package('uptasticsearch')
t$calculate_metrics()
t$plot_network()

t$set_plot_node_color_scheme(field = "node", pallete = c('red','blue','tan','green'))
t$plot_network()```