### PR TITLE
orphan nodes and graphs with no edges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,4 @@ cache: packages
 warnings_are_errors: true
 before_install:
 - Rscript -e "install.packages('roxygen2', repos = 'http://cran.rstudio.org')"
-- Rscript -e "devtools::install('inst/baseballstats')"
-- Rscript -e "devtools::install('inst/sartre')"
-
-
-before_deploy:
-- Rscript -e "devtools::uninstall('inst/baseballstats')"
-- Rscript -e "devtools::uninstall('inst/sartre')"
+- Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.org')"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ cache: packages
 warnings_are_errors: true
 before_install:
 - Rscript -e "install.packages('roxygen2', repos = 'http://cran.rstudio.org')"
+- Rscript -e "devtools::install('inst/baseballstats')"
+- Rscript -e "devtools::install('inst/sartre')"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,8 @@ before_install:
 - Rscript -e "install.packages('roxygen2', repos = 'http://cran.rstudio.org')"
 - Rscript -e "devtools::install('inst/baseballstats')"
 - Rscript -e "devtools::install('inst/sartre')"
+
+
+before_deploy:
+- Rscript -e "devtools::uninstall('inst/baseballstats')"
+- Rscript -e "devtools::uninstall('inst/sartre')"

--- a/R/AbstractGraphReporter.R
+++ b/R/AbstractGraphReporter.R
@@ -188,6 +188,8 @@ AbstractGraphReporter <- R6::R6Class(
               plotDTedges[, from := SOURCE]
               plotDTedges[, to := TARGET]
               plotDTedges[, color := '#848484'] # TODO Make edge formatting flexible too
+            } else {
+              plotDTedges <- NULL
             }
 
             

--- a/R/PackageFunctionReporter.R
+++ b/R/PackageFunctionReporter.R
@@ -82,7 +82,7 @@ PackageFunctionReporter <- R6::R6Class(
             numFuncs <- as.character(unlist(utils::lsf.str(asNamespace(private$packageName)))) # list of functions within Package
             if (length(numFuncs) == 1) {
                 log_info("Only one function. Edge list is null.")
-                return(NULL)
+              return(invisible(NULL))
             }
             
             log_info(sprintf('Constructing network representation...'))
@@ -96,7 +96,7 @@ PackageFunctionReporter <- R6::R6Class(
             
             # If no edges, return NULL
             if (nrow(edges) == 0) {
-              return(NULL)
+              return(invisible(NULL))
             }
             
             return(edges)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -9,4 +9,12 @@ Sys.setenv("R_TESTS" = "")
 
 library(pkgnet)
 
+# Install Fake Packages - For local testing if not already installed
+devtools::install_local(system.file('baseballstats',package="pkgnet"),force=TRUE)
+devtools::install_local(system.file('sartre',package="pkgnet"),force=TRUE)
+
 testthat::test_check('pkgnet')
+
+# Uninstall Fake Packages - For local testing 
+devtools::uninstall(system.file('baseballstats',package="pkgnet"))
+devtools::uninstall(system.file('sartre',package="pkgnet"))

--- a/tests/testthat/test-CreatePackageReport.R
+++ b/tests/testthat/test-CreatePackageReport.R
@@ -4,7 +4,6 @@ context("CreatePackageReport")
 futile.logger::flog.threshold(0,name=futile.logger::flog.namespace())
 
 test_that("Test that CreatingPackageReport Runs", {
-    devtools::install_local(system.file('baseballstats',package="pkgnet"),force=TRUE)
     #TODO: Change when generating reports
     pdf("test_plots.pdf") #PDF doesn't actually work
     reporters <- CreatePackageReport(packageName = "baseballstats")

--- a/tests/testthat/test-functional_structure.R
+++ b/tests/testthat/test-functional_structure.R
@@ -15,8 +15,13 @@ futile.logger::flog.threshold(0)
 # This if block is to protect against some craziness that happens when
 # covr runs tests. TL;DR covr runs your tests in a temp file so the package
 # source isn't available to you.
-devtools::install('../../inst/baseballstats', force = FALSE)
-devtools::install('../../inst/sartre', force = FALSE)
+if (dir.exists('../../inst/baseballstats')){
+  devtools::install('../../inst/baseballstats', force = FALSE)
+}
+
+if (dir.exists('../../inst/baseballstats')){
+  devtools::install('../../inst/sartre', force = FALSE)
+}
 
 # Find the path to the "baseballstats" package we use to test pkgnet
 # (can get a weird path if you're in development mode)

--- a/tests/testthat/test-functional_structure.R
+++ b/tests/testthat/test-functional_structure.R
@@ -1,51 +1,83 @@
-# context("Graph-creation functions")
-# 
-# # Configure logger (suppress all logs in testing)
-# loggerOptions <- futile.logger::logger.options()
-# if (!identical(loggerOptions, list())){
-#     origLogThreshold <- loggerOptions[[1]][['threshold']]    
-# } else {
-#     origLogThreshold <- futile.logger::INFO
-# }
-# futile.logger::flog.threshold(0)
-# 
-# ##### TEST SETUP #####
-# 
-# # Need to manually install the dummy package we use for testing `pkgnet`.
-# # This if block is to protect against some craziness that happens when
-# # covr runs tests. TL;DR covr runs your tests in a temp file so the package
-# # source isn't available to you.
-# if (dir.exists('../../inst/baseballstats')){
-#     devtools::install('../../inst/baseballstats', force = FALSE)
-# }
-# 
-# # Find the path to the "baseballstats" package we use to test pkgnet
-# # (can get a weird path if you're in development mode)
-# TEST_PKG_PATH <- file.path(.libPaths()[1], 'pkgnet', 'baseballstats')
-# 
-# ##### RUN TESTS #####
-# 
-# #--- 1. ExtractNetwork
-# 
-#     # ExtractNetwork should run end-to-end
-#     test_that('ExtractNetwork runs end-to-end', expect_true({
-#                 x <- ExtractNetwork(pkgName = 'baseballstats'
-#                                     , pkgPath = TEST_PKG_PATH)
-#                 TRUE
-#     }))
-# 
-# #--- 2. PlotNetwork
-# 
-#     # PlotNetwork should run end-to-end
-#     test_that('PlotNetwork runs end-to-end', expect_true({
-#         baseballGraph <- ExtractNetwork(pkgName = 'baseballstats'
-#                                         , pkgPath = TEST_PKG_PATH)
-#         plotObject <- PlotNetwork(baseballGraph, colorFieldName = 'test_coverage')
-#         TRUE
-#     }))
-#     
-# 
-# ##### TEST TEAR DOWN #####
-# futile.logger::flog.threshold(origLogThreshold)
-# rm(list = ls())
-# closeAllConnections()
+context("Creation of graph of package functions")
+
+# Configure logger (suppress all logs in testing)
+loggerOptions <- futile.logger::logger.options()
+if (!identical(loggerOptions, list())){
+    origLogThreshold <- loggerOptions[[1]][['threshold']]
+} else {
+    origLogThreshold <- futile.logger::INFO
+}
+futile.logger::flog.threshold(0)
+
+##### TEST SETUP #####
+
+# Need to manually install the dummy package we use for testing `pkgnet`.
+# This if block is to protect against some craziness that happens when
+# covr runs tests. TL;DR covr runs your tests in a temp file so the package
+# source isn't available to you.
+if (dir.exists('../../inst/baseballstats')){
+    devtools::install('../../inst/baseballstats', force = FALSE)
+}
+
+if (dir.exists('../../inst/sartre')){
+  devtools::install('../../inst/sartre', force = FALSE)
+}
+
+# Find the path to the "baseballstats" package we use to test pkgnet
+# (can get a weird path if you're in development mode)
+TEST_PKG_PATH_BBALL <- file.path(.libPaths()[1], 'pkgnet', 'baseballstats')
+TEST_PKG_PATH_SARTRE <- file.path(.libPaths()[1], 'pkgnet', 'baseballstats')
+
+##### RUN TESTS #####
+
+
+  test_that('PackageFunctionReporter returns graph of functions', {
+        t <- PackageFunctionReporter$new()
+        t$set_package(packageName = "baseballstats")
+        t$calculate_metrics()
+        
+        # Nodes
+        expect_equivalent(object = t$get_raw_data()$nodes$node
+                          , expected = as.character(unlist(utils::lsf.str(asNamespace(t$get_package()))))
+                          , info = "All functions are nodes, even ones without connections.")
+        
+        expect_true(object = is.element("node", names(t$get_raw_data()$nodes))
+                    , info = "Node column created")
+        
+        expect_s3_class(object = t$get_raw_data()$nodes
+                        , class =  "data.table")
+        
+        # Edges
+        expect_s3_class(object = t$get_raw_data()$edges
+                        , class =  "data.table")
+        
+        expect_true(object = all(c("TARGET", "SOURCE") %in% names(t$get_raw_data()$edges))
+                    , info = "TARGET and SCORE fields in edge table at minimum")
+
+        # Plots
+        expect_silent(object = t$plot_network())
+        
+  })
+
+  test_that('PackageFunctionReporter works on edge case one function', {
+    t2 <- PackageFunctionReporter$new()
+    t2$set_package('sartre')
+    t2$calculate_metrics()
+    
+    expect_true(object = (nrow(t2$get_raw_data()$nodes) == 1)
+                , info = "One row in nodes table."
+                )
+    
+    expect_true(object = is.null(t2$get_raw_data()$edges)
+                , info = "Edges table is null since there are no edges."
+                )
+    
+    expect_silent(object = t2$plot_network())
+    
+  })
+
+
+##### TEST TEAR DOWN #####
+futile.logger::flog.threshold(origLogThreshold)
+rm(list = ls())
+closeAllConnections()

--- a/tests/testthat/test-functional_structure.R
+++ b/tests/testthat/test-functional_structure.R
@@ -11,33 +11,19 @@ futile.logger::flog.threshold(0)
 
 ##### TEST SETUP #####
 
-# During Travis CI Setup, packages will be installed. 
-# This is to install locally if they have not been installed already. 
-# if (require("baseballstats") == FALSE){
-#   devtools::install(file.path('../../inst/baseballstats')
-#                     , force = FALSE)
-# }
-# 
-# if (require("sartre") == FALSE){
-#   devtools::install(file.path('../../inst/sartre')
-#                     , force = FALSE)
-# }
-# 
-# # Find the path to the "baseballstats" package we use to test pkgnet
-# # (can get a weird path if you're in development mode)
-# library(baseballstats)
-# TEST_PKG_PATH_BBALL <- find.package("baseballstats")
-# library(sartre)
-# TEST_PKG_PATH_SARTRE <- find.package("sartre")
+
 
 ##### RUN TESTS #####
 
-  test_that('test packages loaded alright',{
-    expect_true(object = is.element('baseballstats', loadedNamespaces())
-                , info = "Fake test package baseballstats is loaded.")
+# Note: Packages 'baseballstats' and 'sartre' are installed by Travis CI before testing
+#       and uninstalled after testing.  If running these tests locallaly. 
+
+  test_that('test packages installed alright',{
+    expect_true(object = require("baseballstats")
+                , info = "Fake test package baseballstats is not installed.")
     
-    expect_true(object = is.element('sartre', loadedNamespaces())
-                , info = "Fake test package sartre is loaded.")
+    expect_true(object =  require("sartre")
+                , info = "Fake test package sartre is not installed")
   })
 
   test_that('PackageFunctionReporter returns graph of functions', {
@@ -87,10 +73,6 @@ futile.logger::flog.threshold(0)
 
 
 ##### TEST TEAR DOWN #####
-
-# uninstall fake test packages
-devtools::uninstall(file.path('../../inst/baseballstats'))
-devtools::uninstall(file.path('../../inst/sartre'))
 
 futile.logger::flog.threshold(origLogThreshold)
 rm(list = ls())

--- a/tests/testthat/test-functional_structure.R
+++ b/tests/testthat/test-functional_structure.R
@@ -26,7 +26,7 @@ if (dir.exists('../../inst/sartre')){
 # Find the path to the "baseballstats" package we use to test pkgnet
 # (can get a weird path if you're in development mode)
 TEST_PKG_PATH_BBALL <- file.path(.libPaths()[1], 'pkgnet', 'baseballstats')
-TEST_PKG_PATH_SARTRE <- file.path(.libPaths()[1], 'pkgnet', 'baseballstats')
+TEST_PKG_PATH_SARTRE <- file.path(.libPaths()[1], 'pkgnet', 'sartre')
 
 ##### RUN TESTS #####
 

--- a/tests/testthat/test-functional_structure.R
+++ b/tests/testthat/test-functional_structure.R
@@ -13,22 +13,22 @@ futile.logger::flog.threshold(0)
 
 # During Travis CI Setup, packages will be installed. 
 # This is to install locally if they have not been installed already. 
-if (require("baseballstats") == FALSE){
-  devtools::install(file.path('../../inst/baseballstats')
-                    , force = FALSE)
-}
-
-if (require("sartre") == FALSE){
-  devtools::install(file.path('../../inst/sartre')
-                    , force = FALSE)
-}
-
-# Find the path to the "baseballstats" package we use to test pkgnet
-# (can get a weird path if you're in development mode)
-library(baseballstats)
-TEST_PKG_PATH_BBALL <- find.package("baseballstats")
-library(sartre)
-TEST_PKG_PATH_SARTRE <- find.package("sartre")
+# if (require("baseballstats") == FALSE){
+#   devtools::install(file.path('../../inst/baseballstats')
+#                     , force = FALSE)
+# }
+# 
+# if (require("sartre") == FALSE){
+#   devtools::install(file.path('../../inst/sartre')
+#                     , force = FALSE)
+# }
+# 
+# # Find the path to the "baseballstats" package we use to test pkgnet
+# # (can get a weird path if you're in development mode)
+# library(baseballstats)
+# TEST_PKG_PATH_BBALL <- find.package("baseballstats")
+# library(sartre)
+# TEST_PKG_PATH_SARTRE <- find.package("sartre")
 
 ##### RUN TESTS #####
 

--- a/tests/testthat/test-functional_structure.R
+++ b/tests/testthat/test-functional_structure.R
@@ -15,13 +15,8 @@ futile.logger::flog.threshold(0)
 # This if block is to protect against some craziness that happens when
 # covr runs tests. TL;DR covr runs your tests in a temp file so the package
 # source isn't available to you.
-if (dir.exists('../../inst/baseballstats')){
-    devtools::install('../../inst/baseballstats', force = FALSE)
-}
-
-if (dir.exists('../../inst/sartre')){
-  devtools::install('../../inst/sartre', force = FALSE)
-}
+devtools::install('../../inst/baseballstats', force = FALSE)
+devtools::install('../../inst/sartre', force = FALSE)
 
 # Find the path to the "baseballstats" package we use to test pkgnet
 # (can get a weird path if you're in development mode)
@@ -30,6 +25,13 @@ TEST_PKG_PATH_SARTRE <- file.path(.libPaths()[1], 'pkgnet', 'sartre')
 
 ##### RUN TESTS #####
 
+  test_that('test packages loaded alright',{
+    expect_true(object = is.element('baseballstats', loadedNamespaces())
+                , info = "Fake test package baseballstats is loaded.")
+    
+    expect_true(object = is.element('sartre', loadedNamespaces())
+                , info = "Fake test package sartre is loaded.")
+  })
 
   test_that('PackageFunctionReporter returns graph of functions', {
         t <- PackageFunctionReporter$new()
@@ -55,7 +57,7 @@ TEST_PKG_PATH_SARTRE <- file.path(.libPaths()[1], 'pkgnet', 'sartre')
                     , info = "TARGET and SCORE fields in edge table at minimum")
 
         # Plots
-        expect_silent(object = t$plot_network())
+        expect_true(object = is.element("visNetwork", attributes(t$plot_network())))
         
   })
 
@@ -72,7 +74,7 @@ TEST_PKG_PATH_SARTRE <- file.path(.libPaths()[1], 'pkgnet', 'sartre')
                 , info = "Edges table is null since there are no edges."
                 )
     
-    expect_silent(object = t2$plot_network())
+    expect_true(object = is.element("visNetwork", attributes(t2$plot_network())))
     
   })
 


### PR DESCRIPTION
For the functional dependencies, the node list is decoupled from the edge list.  Now, graphs can have orphan nodes (functions without any dependencies or decedents) as well as no edges (all orphan functions).  Plotting is updated as well