### PR TITLE
Feature/color by coverage

### DIFF
--- a/R/PackageFunctionReporter.R
+++ b/R/PackageFunctionReporter.R
@@ -171,6 +171,39 @@ PackageFunctionReporter <- R6::R6Class(
             }
             
             return(edges)
+        }, 
+        
+        # TODO [patrick.bouer@uptake.com]: Implement packageTestCoverage metrics
+        package_test_coverage = function(){
+          # Given private$nodes & package path
+          # result: update nodes table 
+          
+          repoPath <- file.path(self$get_package_path())
+          
+          log_info(msg = "Calculating package coverage...")
+          pkgCov <- covr::package_coverage(path = repoPath)
+          pkgCov <- data.table::as.data.table(pkgCov)
+          pkgCov <- pkgCov[, list(totalLines = .N
+                                  , coveredLines = sum(value > 0)
+                                  , coverageRatio = sum(value > 0) / .N
+                                  , filename = filename[1]
+                                  , firstLineInFile = first_line[1]
+                                  , lastLineInFile = last_line[.N]
+          )
+          , by = list(node = functions)]
+          
+          # Update Node with Coverage Info
+          private$nodes <- merge(x = private$nodes
+                                 , y = pkgCov
+                                 , by = "node"
+                                 , all.x = TRUE)
+          
+          self$set_plot_node_color_scheme(field = "coverageRatio"
+                                          , pallete = c("red", "green")
+          )
+          
+          log_info(msg = "Done calculating package coverage.")
+          return(invisible(NULL))
         }
         
     ),

--- a/R/PackageFunctionReporter.R
+++ b/R/PackageFunctionReporter.R
@@ -74,7 +74,12 @@ PackageFunctionReporter <- R6::R6Class(
                                              , type = "tests"
                                              , combine_types = FALSE)
             pkgCov <- data.table::as.data.table(pkgCov)
-            pkgCov <- pkgCov[, list(coverage = sum(value > 0)/.N)
+            pkgCov <- pkgCov[, list(coveredLines = sum(value > 0)
+                                    , totalLines = .N
+                                    , coverageRatio = sum(value > 0)/.N
+                                    , meanCoveragePerLine = sum(value)/.N
+                                    , filename = filename[1]
+                                    )
                              , by = list(node = functions)]
             
             # Update Node with Coverage Info

--- a/tests/testthat/test-CreatePackageReport.R
+++ b/tests/testthat/test-CreatePackageReport.R
@@ -1,6 +1,12 @@
 context("CreatePackageReport")
 
-#Supress logger in tests
+# Configure logger (suppress all logs in testing)
+loggerOptions <- futile.logger::logger.options()
+if (!identical(loggerOptions, list())){
+  origLogThreshold <- loggerOptions[[1]][['threshold']]
+} else {
+  origLogThreshold <- futile.logger::INFO
+}
 futile.logger::flog.threshold(0,name=futile.logger::flog.namespace())
 
 test_that("Test that CreatingPackageReport Runs", {
@@ -12,3 +18,10 @@ test_that("Test that CreatingPackageReport Runs", {
     testthat::expect_true(file.exists("test_plots.pdf") && file.size("test_plots.pdf") > 0)
     file.remove("test_plots.pdf")
 })
+
+
+##### TEST TEAR DOWN #####
+
+futile.logger::flog.threshold(origLogThreshold)
+rm(list = ls())
+closeAllConnections()

--- a/tests/testthat/test-PackageFunctionReporter.R
+++ b/tests/testthat/test-PackageFunctionReporter.R
@@ -41,6 +41,7 @@ test_that('PackageFunctionReporter structure is as expected', {
   expect_named(object = PackageFunctionReporter$private_methods
                , expected = c("extract_nodes"
                               , "extract_edges"
+                              , "package_test_coverage"
                               )
                , info = "Available private methods for PackageFunctionReporter not as expected."
                , ignore.order = TRUE
@@ -163,8 +164,12 @@ test_that('PackageFunctionReporter Methods Work', {
   )
   
   # coverage
-  #TODO this will need to be updated after PR #40
-  expect_true(object = all( c("coverage") %in% names(testObj$nodes))
+  expect_true(object = all( c("coverageRatio"
+                              , "meanCoveragePerLine"
+                              , "totalLines"
+                              , "coveredLines"
+                              , "filename") %in% names(testObj$nodes)
+                            )
               , info = "Not all expected function coverages measures are in nodes table"
   )
   

--- a/tests/testthat/test-plotting.R
+++ b/tests/testthat/test-plotting.R
@@ -1,18 +1,30 @@
-context("Plotting")
+context("Plotting Tests")
 
+##### TEST SET UP #####
+
+rm(list = ls())
+# Configure logger (suppress all logs in testing)
+# expect_silents only work with this logger turned off; only alerts with warnings
+loggerOptions <- futile.logger::logger.options()
+if (!identical(loggerOptions, list())){
+  origLogThreshold <- loggerOptions[[1]][['threshold']]
+} else {
+  origLogThreshold <- futile.logger::INFO
+}
+futile.logger::flog.threshold(0)
 
 test_that('node coloring by discrete and continuous', {
   b <- PackageFunctionReporter$new()
   b$set_package('baseballstats', packagePath = system.file('baseballstats',package="pkgnet"))
-  b$calculate_metrics()
+  b$calculate_all_metrics()
   b$get_raw_data()
   b$set_plot_node_color_scheme(field = "coverageRatio"
                                , pallete = c("red", "green")
   )
   
   expect_silent(object = b$plot_network())
-                #, regexp = "Done creating plot"
-               #, info = "Plot with continuous coloring has issues")
+               #  , regexp = "Coloring plot nodes by coverageRatio"
+               # , info = "Plot with continuous coloring has issues")
   
   b$set_plot_node_color_scheme(field = "filename"
                                , pallete = c("#E41A1C"
@@ -27,7 +39,13 @@ test_that('node coloring by discrete and continuous', {
   )
   
   expect_silent(object = b$plot_network())
-                # , regexp = "Done creating plot"
-                # , info = "Plot with continuous coloring has issues")
+                 # , regexp = "Coloring plot nodes by filename"
+                 # , info = "Plot by character fields has issues")
   
 })
+
+##### TEST TEAR DOWN #####
+
+futile.logger::flog.threshold(origLogThreshold)
+rm(list = ls())
+closeAllConnections()

--- a/tests/testthat/test-plotting.R
+++ b/tests/testthat/test-plotting.R
@@ -1,0 +1,25 @@
+context("Plotting")
+
+
+test_that('node coloring by discrete and continuous', {
+  b <- PackageFunctionReporter$new()
+  b$set_package('baseballstats', packagePath = system.file('baseballstats',package="pkgnet"))
+  b$calculate_metrics()
+  b$get_raw_data()
+  b$set_plot_node_color_scheme(field = "coverageRatio"
+                               , pallete = c("red", "green")
+  )
+  
+  expect_output(object = plotObj <- b$plot_network()
+                , regexp = "Done creating plot"
+                , info = "Plot with continuous coloring has issues")
+  
+  b$set_plot_node_color_scheme(field = "filename"
+                               , pallete = RColorBrewer::brewer.pal(9,"Set1")
+  )
+  
+  expect_output(object = plotObj <- b$plot_network()
+                , regexp = "Done creating plot"
+                , info = "Plot with continuous coloring has issues")
+  
+})

--- a/tests/testthat/test-plotting.R
+++ b/tests/testthat/test-plotting.R
@@ -15,7 +15,15 @@ test_that('node coloring by discrete and continuous', {
                #, info = "Plot with continuous coloring has issues")
   
   b$set_plot_node_color_scheme(field = "filename"
-                               , pallete = RColorBrewer::brewer.pal(9,"Set1")
+                               , pallete = c("#E41A1C"
+                                             , "#377EB8"
+                                             , "#4DAF4A"
+                                             , "#984EA3"
+                                             , "#FF7F00"
+                                             , "#FFFF33"
+                                             , "#A65628"
+                                             , "#F781BF"
+                                             , "#999999")
   )
   
   expect_silent(object = b$plot_network())

--- a/tests/testthat/test-plotting.R
+++ b/tests/testthat/test-plotting.R
@@ -10,16 +10,16 @@ test_that('node coloring by discrete and continuous', {
                                , pallete = c("red", "green")
   )
   
-  expect_output(object = plotObj <- b$plot_network()
-                , regexp = "Done creating plot"
-                , info = "Plot with continuous coloring has issues")
+  expect_silent(object = b$plot_network())
+                #, regexp = "Done creating plot"
+               #, info = "Plot with continuous coloring has issues")
   
   b$set_plot_node_color_scheme(field = "filename"
                                , pallete = RColorBrewer::brewer.pal(9,"Set1")
   )
   
-  expect_output(object = plotObj <- b$plot_network()
-                , regexp = "Done creating plot"
-                , info = "Plot with continuous coloring has issues")
+  expect_silent(object = b$plot_network())
+                # , regexp = "Done creating plot"
+                # , info = "Plot with continuous coloring has issues")
   
 })


### PR DESCRIPTION
Addresses #9 and allows node coloring for continuous values (such as `coverageRatio`) and discrete values (such as `filename`). 