### PR TITLE
Edge direction

### DIFF
--- a/R/AbstractGraphReporter.R
+++ b/R/AbstractGraphReporter.R
@@ -284,7 +284,7 @@ AbstractGraphReporter <- R6::R6Class(
             g <- visNetwork::visNetwork(nodes = plotDTnodes
                                         , edges = plotDTedges) %>%
                 visNetwork::visHierarchicalLayout(sortMethod = "directed"
-                                                  , direction = "DU") %>%
+                                                  , direction = "UD") %>%
                 visNetwork::visEdges(arrows = 'to') %>%
                 visNetwork::visOptions(highlightNearest = list(enabled = TRUE
                                                                , degree = nrow(plotDTnodes) #guarantee full path

--- a/R/PackageDependencyReporter.R
+++ b/R/PackageDependencyReporter.R
@@ -114,8 +114,8 @@ PackageDependencyReporter <- R6::R6Class(
             edges <- data.table::rbindlist(lapply(
                 names(dependencyList), 
                 function(pkgN){
-                    data.table::data.table(SOURCE = rep(pkgN,length(dependencyList[[pkgN]])), 
-                                           TARGET = dependencyList[[pkgN]])
+                    data.table::data.table(SOURCE = dependencyList[[pkgN]], 
+                                           TARGET = rep(pkgN,length(dependencyList[[pkgN]])))
                     }
                 ))
             

--- a/tests/testthat/test-PackageDependencyReporter.R
+++ b/tests/testthat/test-PackageDependencyReporter.R
@@ -101,13 +101,13 @@ test_that('PackageDependencyReporter Methods Work', {
                , ignore.case = FALSE
   )
   
-  expect_true(object = all(networkDTList$edges[,unique(SOURCE, TARGET)] %in% c("baseballstats",
-                                                                       "methods",
-                                                                       "methods",
-                                                                       "stats",
-                                                                       "stats",
-                                                                       "stats",
-                                                                       "graphics"))
+  expect_true(object = all(networkDTList$edges[,unique(c(SOURCE, TARGET))] %in% c("base",
+                                                                               "methods",
+                                                                               "utils",
+                                                                               "stats",
+                                                                               "grDevices",
+                                                                               "graphics", 
+                                                                               "baseballstats"))
               , info = "unexpected package dependencies derived for baseballstats"
   )
   


### PR DESCRIPTION
I changed the package dependency edge direction to the convention we agreed upon the other day.  

Run this: `t <- pkgnet::CreatePackageReport(packageName = "baseballstats")`

![rplot](https://user-images.githubusercontent.com/24531403/35427888-9f38c4be-0231-11e8-9a08-5cc4dede7312.png)
![rplot01](https://user-images.githubusercontent.com/24531403/35427889-9f497c6e-0231-11e8-8e06-f91f89fdf4ab.png)

