### PR TITLE
reinstate basic package summary reporter

### DIFF
--- a/R/DefaultReporters.R
+++ b/R/DefaultReporters.R
@@ -4,7 +4,8 @@
 #' @export
 DefaultReporters <- function() {
     return(list(
-         PackageFunctionReporter$new()
+          PackageSummaryReporter$new()
+        , PackageFunctionReporter$new()
         , PackageDependencyReporter$new()
     ))
 }

--- a/R/PackageSummaryReporter.R
+++ b/R/PackageSummaryReporter.R
@@ -19,9 +19,13 @@ PackageSummaryReporter <- R6::R6Class(
         get_objects = function(){
             return(private$packageObjects)
         },
-        calculate_metrics = function(){
+        calculate_all_metrics = function(){
             private$get_package_description()
             private$get_num_objects()
+        }, 
+        plot_network = function(){
+          # No network in summary reporter
+          return(NULL)
         }
     ),
     

--- a/inst/package_report/package_summary_reporter.Rmd
+++ b/inst/package_report/package_summary_reporter.Rmd
@@ -11,7 +11,7 @@ params:
 This report will give you a high level description of a package
 
 
-```{r}
+```{r comment=NA}
 reporter$get_description()
 ```
 

--- a/inst/package_report/package_summary_reporter.Rmd
+++ b/inst/package_report/package_summary_reporter.Rmd
@@ -5,7 +5,9 @@ params:
    reporter: params$reporter
 ---
 
-## Description
+## Package Summary
+
+### Description
 This report will give you a high level description of a package
 
 
@@ -13,7 +15,7 @@ This report will give you a high level description of a package
 reporter$get_description()
 ```
 
-## Num Objects
+### Num Objects
 
 Number of objects
 


### PR DESCRIPTION
This reinstates the PackageSummaryReporter back into the report.  The formatting is not great, but it generates. 


