### PR TITLE
Update Report Format & Update Repo Website

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,16 +17,16 @@ Imports:
     assertthat,
     covr,
     data.table,
+    DT,
     futile.logger,
     igraph,
+    knitr,
     magrittr,
     methods,
     mvbutils,
     R6,
-    visNetwork, 
-    rmarkdown, 
-    knitr, 
-    DT
+    rmarkdown,
+    visNetwork
 Suggests:
     devtools,
     testthat

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Imports:
     R6,
     visNetwork, 
     rmarkdown, 
-    knitr
+    knitr, 
+    DT
 Suggests:
     devtools,
     testthat

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 ************************************************************************
-Copyright (c) 2017, Uptake
+Copyright (c) 2018, Uptake
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/R/PackageSummaryReporter.R
+++ b/R/PackageSummaryReporter.R
@@ -14,7 +14,11 @@ PackageSummaryReporter <- R6::R6Class(
             system.file(file.path("package_report","package_summary_reporter.Rmd"),package = "pkgnet")
         },
         get_description = function(){
-            return(private$packageDescription)
+            obj <- private$packageDescription
+            dt <- data.table::data.table(Field = names(obj)
+                                         , Values = unlist(obj)
+                                         )
+            return(dt)
         },
         get_objects = function(){
             return(private$packageObjects)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,6 @@
 template:
   params:
-    bootswatch: cosmo
+    bootswatch: flatly
 
 navbar:
   title: "pkgnet"
@@ -15,8 +15,4 @@ navbar:
    - icon: fa-github
      href: https://github.com/uptakeopensource/pkgnet
 
-reference:
-  - title: "Network Extraction"
-    contents:
-      - ExtractDependencyNetwork
-      - ExtractFunctionNetwork
+

--- a/docs/LICENSE.html
+++ b/docs/LICENSE.html
@@ -11,7 +11,7 @@
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
-<link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/cosmo/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+<link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
 
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
@@ -81,7 +81,7 @@
     </div>
 
 <pre>************************************************************************
-Copyright (c) 2017, Uptake
+Copyright (c) 2018, Uptake
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -124,7 +124,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -11,7 +11,7 @@
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
-<link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/cosmo/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+<link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
 
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
@@ -93,6 +93,10 @@
         <p><strong>Patrick Boueri</strong>. Contributor.
         </p>
       </li>
+      <li>
+        <p><strong>Jay Qi</strong>. Contributor.
+        </p>
+      </li>
     </ul>
 
   </div>
@@ -106,7 +110,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Get Network Representation of an R Package • pkgnet</title>
-<!-- jquery --><script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script><!-- Bootstrap --><link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/cosmo/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+<!-- jquery --><script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script><!-- Bootstrap --><link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script><!-- Font Awesome icons --><link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
 <!-- pkgdown --><link href="pkgdown.css" rel="stylesheet">
 <script src="jquery.sticky-kit.min.js"></script><script src="pkgdown.js"></script><!-- mathjax --><script src="https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script><!--[if lt IE 9]>
@@ -133,7 +133,7 @@ result &lt;- CreatePackageReport('ggplot2')</code></pre>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/AbstractGraphReporter.html
+++ b/docs/reference/AbstractGraphReporter.html
@@ -11,7 +11,7 @@
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
-<link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/cosmo/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+<link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
 
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
@@ -96,14 +96,34 @@
 
     
     <dl class='dl-horizontal'>
-    <code>calculate_network_metrics</code>Uses <code>CalcNetworkFeatures</code> to 
-         calculate nodes and edges to create summary metrics of the overall 
-         graph structure, including centrality measures etc.
-       <code>get_summary_view</code>Returns the output of calculateNetworkMetrics
-       <code>set_graph_layout</code>Accepts a layoutType from either "tree" or "circle"
-         and augments the nodes private field with level/horizontal coordinates 
-         for a prettified layout
-       <code>plot_network</code>Calls <code>PlotNetwork</code> and returns a plotly object
+    <code>calculate_network_measures()</code>
+            <ul>
+<li><p>extract network features on a node and network level</p></li>
+<li><p><b>Returns:</b> A list containing:
+                    <ul>
+<li><p><b><code>networkMeasures</code></b>: a list of network measures.</p></li>
+<li><p><b><code>nodeMeasures</code></b>: the nodes data.table with additional columns of node measures.</p></li>
+</ul></p></li>
+</ul>
+    <code>set_graph_layout</code>Sets the layout of the graph plotted by
+           <code>plot_network</code>. This method augments the nodes data.table
+           with level/horizontal coordinates. The following layout types are
+           supported:<ul>
+<li><p>`tree` (default)</p></li>
+<li><p>`circle`</p></li>
+</ul>
+        <code>plot_network</code>
+            <ul>
+<li><p>Creates a network visualization of extracted package graph.</p></li>
+<li><p><b>Args:</b>
+                    <ul>
+<li><p><b><code>...</code></b>: ...</p></li>
+</ul></p></li>
+<li><p><b>Returns:</b>
+                    <ul>
+<li><p>A `visNetwork` object</p></li>
+</ul></p></li>
+</ul>
     </dl>
     
     <h2 class="hasAnchor" id="public-members"><a class="anchor" href="#public-members"></a>Public Members</h2>
@@ -113,7 +133,9 @@
     <code>edges</code>A data.table from SOURCE to TARGET nodes describing the connections
    <code>nodes</code>A data.table with node as an identifier, and augmenting information about each node
    <code>pkgGraph</code>An igraph object describing the package graph
-   <code>networkMeasures</code>A list of network measures calculated by <code>CalcNetworkFeatures</code>
+   <code>networkMeasures</code>A list of network measures calculated by <code>calculate_network_features</code>
+   <code>graphLayoutType</code>Character string indicating currently active graph layout
+   <code>graphViz</code><code>visNetwork</code> object of package graph
     </dl>
     
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>
@@ -144,7 +166,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/AbstractPackageReporter.html
+++ b/docs/reference/AbstractPackageReporter.html
@@ -11,7 +11,7 @@
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
-<link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/cosmo/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+<link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
 
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
@@ -92,7 +92,7 @@
 
     <p>An object of class <code>R6ClassGenerator</code> of length 24.</p>
     
-    <h2 class="hasAnchor" id="public-methods"><a class="anchor" href="#public-methods"></a>Public Methods</h2>
+    <h2 class="hasAnchor" id="public"><a class="anchor" href="#public"></a>Public</h2>
 
     
     <dl class='dl-horizontal'>
@@ -106,13 +106,20 @@
                 <ul>
 <li><p><b><code>packageName</code></b>: a string with the name of the package you are
                   analyzing.</p></li>
+<li><p><b><code>packagePath</code></b>: directory path to source code of package</p></li>
 </ul></p></li>
 </ul></p></dd>
     <dt><code>get_report()</code></dt><dd><p><ul>
 <li><p>Returns a particular reporter's report on the package</p></li>
 </ul></p></dd>
+    <dt><code>get_report_markdown_path()</code></dt><dd><p><ul>
+<li><p>Returns the path to the markdown report associated with this reporter</p></li>
+</ul></p></dd>
     <dt><code>get_summary_view()</code></dt><dd><p><ul>
-<li><p>Returns a particular reporters summary report on the package</p></li>
+<li><p>Returns a particular reporters summary report on the package for use in a high level view</p></li>
+</ul></p></dd>
+    <dt><code>calculate_package_metrics()</code></dt><dd><p><ul>
+<li><p>Calculates all the relevant metrics for a set package and updates the reporter</p></li>
 </ul></p></dd>
     <dt><code>get_raw_data()</code></dt><dd><p><ul>
 <li><p>Returns a particular reporter's raw data.</p></li>
@@ -141,7 +148,7 @@
       
       <li><a href="#format">Format</a></li>
 
-      <li><a href="#public-methods">Public Methods</a></li>
+      <li><a href="#public">Public</a></li>
 
       <li><a href="#abstract-methods">Abstract Methods</a></li>
 
@@ -157,7 +164,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/DefaultReporters.html
+++ b/docs/reference/DefaultReporters.html
@@ -11,7 +11,7 @@
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
-<link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/cosmo/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+<link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
 
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
@@ -102,7 +102,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/PackageDependencyReporter.html
+++ b/docs/reference/PackageDependencyReporter.html
@@ -11,7 +11,7 @@
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
-<link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/cosmo/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+<link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
 
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
@@ -83,7 +83,7 @@
     
     <p>This Reporter takes a package and uncovers the structure from
              its other package dependencies, determining which package it relies on is most central,
-             allowing for a developer to determine how to vett its dependency tree</p>
+             allowing for a developer to determine how to vet its dependency tree</p>
     
 
     <pre class="usage"><span class='no'>PackageDependencyReporter</span></pre>
@@ -96,20 +96,35 @@
 
     
     <dl class='dl-horizontal'>
-    <dt><code>set_package(packageName, ...)</code></dt><dd><p><ul>
-<li><p>Set the package that all operations in the object are done for.</p></li>
+    <dt><code>extract_network(which = "Imports", installed = TRUE, ignorePackages = NULL)</code></dt><dd><p><ul>
+<li><p>This function maps a package's reverse dependency
+                  network, allowing for analysis of a package's imports</p></li>
 <li><p><b>Args:</b>
                 <ul>
-<li><p><b><code>packageName</code></b>: a string with the name of the package you are
-                  analyzing.</p></li>
-<li><p><b><code>...</code></b>: other arguments passed through to <code>ExtractDependencyNetwork</code></p></li>
+<li><p><b><code>depTypes</code></b>: a character vector passed on to <code>which</code> argument of
+                    <a href='http://www.rdocumentation.org/packages/tools/topics/package_dependencies'>package_dependencies</a> indicating what to count
+                    as a package dependency. Default is "Imports".</p></li>
+<li><p><b><code>installed</code></b>: a boolean whether to consider installed
+                    packages or CRAN packages. default is TRUE. FALSE is useful if you 
+                    would like to vet a package before adding it as a dependency</p></li>
+<li><p><b><code>ignorePackages</code></b>: a vector of package names to ignore 
+                    in dependency analysis. They will show up if a package depends on them
+                    but their dependencies will be ignored. Useful if you know certain packages
+                    are required and have and have a large number of dependencies that clutter
+                    the analysis.</p></li>
+</ul></p></li>
+<li><p><b>Returns: a list with</b>
+            <ul>
+<li><p><b><code>edges</code></b>: A data.table of directed edges from SOURCE package to TARGET package</p></li>
+<li><p><b><code>nodes</code></b>: A data.table of nodes, where each node is a package</p></li>
 </ul></p></li>
 </ul></p></dd>
 </dl>
     
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>
 
-    <p>Other PackageReporters: <code><a href='PackageFunctionReporter.html'>PackageFunctionReporter</a></code></p>
+    <p>Other PackageReporters: <code><a href='PackageFunctionReporter.html'>PackageFunctionReporter</a></code>,
+  <code><a href='PackageSummaryReporter.html'>PackageSummaryReporter</a></code></p>
     
 
   </div>
@@ -133,7 +148,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/PackageFunctionReporter.html
+++ b/docs/reference/PackageFunctionReporter.html
@@ -11,7 +11,7 @@
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
-<link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/cosmo/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+<link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
 
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
@@ -93,17 +93,33 @@
 
     <p>An object of class <code>R6ClassGenerator</code> of length 24.</p>
     
-    <h2 class="hasAnchor" id="dependency-methods"><a class="anchor" href="#dependency-methods"></a>Dependency Methods</h2>
+    <h2 class="hasAnchor" id="public-methods"><a class="anchor" href="#public-methods"></a>Public Methods</h2>
 
     
     <dl class='dl-horizontal'>
-    <code>set_package</code>Uses <code>ExtractFunctionNetwork</code> to create edges
-   <code>package_test_coverage</code>Uses <code>GetCoverageByFunction</code> to calculate node test coverage
-    </dl>
+    <dt><code>set_package(packageName, packagePath)</code></dt><dd><p><ul>
+<li><p>Set properties of this reporter. If packageName overrides a 
+                previously-set package name, any cached data will be removed.</p></li>
+<li><p><b>Args:</b>
+                <ul>
+<li><p><b><code>packageName</code></b>: String with the name of the package</p></li>
+<li><p><b><code>packagePath</code></b>: Optional path to the source code. 
+                    To be used for test coverage, if provided.</p></li>
+</ul></p></li>
+</ul></p></dd>
+    <dt><code>calculate_metrics()</code></dt><dd><p><ul>
+<li><p>Create an edgelist with relationships between functions in a package</p></li>
+</ul></p></dd>
+    <dt><code>extract_network()</code></dt><dd><p><ul>
+<li><p>This function maps the relationships between
+                  functions in a package.</p></li>
+</ul></p></dd>
+</dl>
     
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>
 
-    <p>Other PackageReporters: <code><a href='PackageDependencyReporter.html'>PackageDependencyReporter</a></code></p>
+    <p>Other PackageReporters: <code><a href='PackageDependencyReporter.html'>PackageDependencyReporter</a></code>,
+  <code><a href='PackageSummaryReporter.html'>PackageSummaryReporter</a></code></p>
     
 
   </div>
@@ -113,7 +129,7 @@
       
       <li><a href="#format">Format</a></li>
 
-      <li><a href="#dependency-methods">Dependency Methods</a></li>
+      <li><a href="#public-methods">Public Methods</a></li>
 
       <li><a href="#see-also">See also</a></li>
           </ul>
@@ -127,7 +143,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/docs/reference/PackageSummaryReporter.html
+++ b/docs/reference/PackageSummaryReporter.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Surface the internal and external dependencies of an R package. — CreatePackageReport • pkgnet</title>
+<title>Package Summary Reporter Class — PackageSummaryReporter • pkgnet</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -77,57 +77,71 @@
       <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-    <h1>Surface the internal and external dependencies of an R package.</h1>
+    <h1>Package Summary Reporter Class</h1>
     </div>
 
     
-    <p>Surface the internal and external dependencies of an R package.</p>
+    <p>Defines a concrete implementation of <a href='AbstractPackageReporter.html'>AbstractPackageReporter</a> for a high level overview
+             of a particular package. It will summarize things like Lines of code, whether it's on CRAN, etc.</p>
     
 
-    <pre class="usage"><span class='fu'>CreatePackageReport</span>(<span class='no'>packageName</span>, <span class='kw'>packageReporters</span> <span class='kw'>=</span> <span class='fu'><a href='DefaultReporters.html'>DefaultReporters</a></span>(),
-  <span class='kw'>packagePath</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>reportPath</span> <span class='kw'>=</span> <span class='fu'>file.path</span>(<span class='fu'>getwd</span>(), <span class='fu'>paste0</span>(<span class='no'>packageName</span>,
-  <span class='st'>"_report.html"</span>)))</pre>
-    
-    <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a> Arguments</h2>
-    <table class="ref-arguments">
-    <colgroup><col class="name" /><col class="desc" /></colgroup>
-    <tr>
-      <th>packageName</th>
-      <td><p>name of a package</p></td>
-    </tr>
-    <tr>
-      <th>packageReporters</th>
-      <td><p>a list of package reporters</p></td>
-    </tr>
-    <tr>
-      <th>packagePath</th>
-      <td><p>(optional) the path to the package repository.
-If given, coverage will be calculated for each function.</p></td>
-    </tr>
-    <tr>
-      <th>reportPath</th>
-      <td><p>The path and filename of the output report.  Default
-report will be produced in working directory.</p></td>
-    </tr>
-    </table>
-    
-    <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
+    <pre class="usage"><span class='no'>PackageSummaryReporter</span></pre>
+        
+    <h2 class="hasAnchor" id="format"><a class="anchor" href="#format"></a>Format</h2>
 
-    <p>A list of instantiated packageReporters the user can then interact with</p>
+    <p>An object of class <code>R6ClassGenerator</code> of length 24.</p>
+    
+    <h2 class="hasAnchor" id="public"><a class="anchor" href="#public"></a>Public</h2>
+
+    
+    <dl class='dl-horizontal'>
+    <dt><code>get_package()</code></dt><dd><p><ul>
+<li><p>Returns a string with the name of the package used to construct
+                this object</p></li>
+</ul></p></dd>
+    <dt><code>set_package(packageName)</code></dt><dd><p><ul>
+<li><p>Set the package that all operations in the object are done for.</p></li>
+<li><p><b>Args:</b>
+                <ul>
+<li><p><b><code>packageName</code></b>: a string with the name of the package you are
+                  analyzing.</p></li>
+<li><p><b><code>packagePath</code></b>: directory path to source code of package</p></li>
+</ul></p></li>
+</ul></p></dd>
+    <dt><code>get_report()</code></dt><dd><p><ul>
+<li><p>Returns a particular reporter's report on the package</p></li>
+</ul></p></dd>
+    <dt><code>get_report_markdown_path()</code></dt><dd><p><ul>
+<li><p>Returns the path to the markdown report associated with this reporter</p></li>
+</ul></p></dd>
+    <dt><code>get_summary_view()</code></dt><dd><p><ul>
+<li><p>Returns a particular reporters summary report on the package for use in a high level view</p></li>
+</ul></p></dd>
+    <dt><code>calculate_package_metrics()</code></dt><dd><p><ul>
+<li><p>Calculates all the relevant metrics for a set package and updates the reporter</p></li>
+</ul></p></dd>
+    <dt><code>get_raw_data()</code></dt><dd><p><ul>
+<li><p>Returns a particular reporter's raw data.</p></li>
+</ul></p></dd>
+</dl>
+    
+    <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>
+
+    <p>Other PackageReporters: <code><a href='PackageDependencyReporter.html'>PackageDependencyReporter</a></code>,
+  <code><a href='PackageFunctionReporter.html'>PackageFunctionReporter</a></code></p>
     
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <h2>Contents</h2>
     <ul class="nav nav-pills nav-stacked">
-      <li><a href="#arguments">Arguments</a></li>
       
-      <li><a href="#value">Value</a></li>
-          </ul>
+      <li><a href="#format">Format</a></li>
 
-    <h2>Author</h2>
-    
-B. Burns
+      <li><a href="#public">Public</a></li>
+
+      <li><a href="#see-also">See also</a></li>
+          </ul>
 
   </div>
 </div>

--- a/docs/reference/RenderPackageReport.html
+++ b/docs/reference/RenderPackageReport.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Surface the internal and external dependencies of an R package. — CreatePackageReport • pkgnet</title>
+<title>Package Report Renderer — RenderPackageReport • pkgnet</title>
 
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
@@ -77,43 +77,35 @@
       <div class="row">
   <div class="col-md-9 contents">
     <div class="page-header">
-    <h1>Surface the internal and external dependencies of an R package.</h1>
+    <h1>Package Report Renderer</h1>
     </div>
 
     
-    <p>Surface the internal and external dependencies of an R package.</p>
+    <p>Renders an html report based on the initialized reporters provided</p>
     
 
-    <pre class="usage"><span class='fu'>CreatePackageReport</span>(<span class='no'>packageName</span>, <span class='kw'>packageReporters</span> <span class='kw'>=</span> <span class='fu'><a href='DefaultReporters.html'>DefaultReporters</a></span>(),
-  <span class='kw'>packagePath</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>reportPath</span> <span class='kw'>=</span> <span class='fu'>file.path</span>(<span class='fu'>getwd</span>(), <span class='fu'>paste0</span>(<span class='no'>packageName</span>,
-  <span class='st'>"_report.html"</span>)))</pre>
+    <pre class="usage"><span class='fu'>RenderPackageReport</span>(<span class='no'>reportPath</span>, <span class='no'>packageReporters</span>, <span class='no'>packageName</span>)</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a> Arguments</h2>
     <table class="ref-arguments">
     <colgroup><col class="name" /><col class="desc" /></colgroup>
     <tr>
-      <th>packageName</th>
-      <td><p>name of a package</p></td>
+      <th>reportPath</th>
+      <td><p>a file.path to where the report should be rendered</p></td>
     </tr>
     <tr>
       <th>packageReporters</th>
-      <td><p>a list of package reporters</p></td>
+      <td><p>a list of package reporters that have already been initialized and have calculated</p></td>
     </tr>
     <tr>
-      <th>packagePath</th>
-      <td><p>(optional) the path to the package repository.
-If given, coverage will be calculated for each function.</p></td>
-    </tr>
-    <tr>
-      <th>reportPath</th>
-      <td><p>The path and filename of the output report.  Default
-report will be produced in working directory.</p></td>
+      <th>packageName</th>
+      <td><p>(string) The name of the package.</p></td>
     </tr>
     </table>
     
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
 
-    <p>A list of instantiated packageReporters the user can then interact with</p>
+    <p>Nothing</p>
     
 
   </div>
@@ -127,7 +119,7 @@ report will be produced in working directory.</p></td>
 
     <h2>Author</h2>
     
-B. Burns
+P. Boueri
 
   </div>
 </div>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -11,7 +11,7 @@
 <!-- jquery -->
 <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
-<link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/cosmo/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+<link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/flatly/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
 
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
@@ -94,22 +94,58 @@
       <tbody>
         <tr>
           <th colspan="2">
-            <h2 id="section-network-extraction" class="hasAnchor"><a href="#section-network-extraction" class="anchor"></a>Network Extraction</h2>
+            <h2 id="section-all-functions" class="hasAnchor"><a href="#section-all-functions" class="anchor"></a>All functions</h2>
             <p class="section-desc"></p>
           </th>
         </tr>
         <tr>
           <!--  -->
           <td>
-            <p><code><a href="ExtractDependencyNetwork.html">ExtractDependencyNetwork</a></code> </p>
+            <p><code><a href="AbstractGraphReporter.html">AbstractGraphReporter</a></code> </p>
           </td>
-          <td><p>Extract the Dependency Network from a Package</p></td>
+          <td><p>Abstract Graph Reporter Class</p></td>
         </tr><tr>
           <!--  -->
           <td>
-            <p><code><a href="ExtractFunctionNetwork.html">ExtractFunctionNetwork</a></code> </p>
+            <p><code><a href="AbstractPackageReporter.html">AbstractPackageReporter</a></code> </p>
           </td>
-          <td><p>Extract the Network Relationship Between Functions in A Package</p></td>
+          <td><p>Abstract Package Reporter Class</p></td>
+        </tr><tr>
+          <!--  -->
+          <td>
+            <p><code><a href="CreatePackageReport.html">CreatePackageReport</a></code> </p>
+          </td>
+          <td><p>Surface the internal and external dependencies of an R package.</p></td>
+        </tr><tr>
+          <!--  -->
+          <td>
+            <p><code><a href="DefaultReporters.html">DefaultReporters</a></code> </p>
+          </td>
+          <td><p>Default Reporters</p></td>
+        </tr><tr>
+          <!--  -->
+          <td>
+            <p><code><a href="PackageDependencyReporter.html">PackageDependencyReporter</a></code> </p>
+          </td>
+          <td><p>Package Dependency Reporter Class</p></td>
+        </tr><tr>
+          <!--  -->
+          <td>
+            <p><code><a href="PackageFunctionReporter.html">PackageFunctionReporter</a></code> </p>
+          </td>
+          <td><p>Package Function Reporter Class</p></td>
+        </tr><tr>
+          <!--  -->
+          <td>
+            <p><code><a href="PackageSummaryReporter.html">PackageSummaryReporter</a></code> </p>
+          </td>
+          <td><p>Package Summary Reporter Class</p></td>
+        </tr><tr>
+          <!--  -->
+          <td>
+            <p><code><a href="RenderPackageReport.html">RenderPackageReport</a></code> </p>
+          </td>
+          <td><p>Package Report Renderer</p></td>
         </tr>
       </tbody>
       </table>
@@ -119,7 +155,7 @@
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">
     <h2>Contents</h2>
     <ul class="nav nav-pills nav-stacked">
-      <li><a href="#section-network-extraction">Network Extraction</a></li>
+      <li><a href="#section-all-functions">All functions</a></li>
     </ul>
   </div>
 </div>
@@ -130,7 +166,7 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 
       </footer>

--- a/inst/package_report/footer.html
+++ b/inst/package_report/footer.html
@@ -1,0 +1,1 @@
+<p>Copyright &copy; 2018 Uptake. 3-Clause BSD License.</p>

--- a/inst/package_report/package_report.Rmd
+++ b/inst/package_report/package_report.Rmd
@@ -1,18 +1,26 @@
 ---
+name: "pkgnet"
 output: 
   html_document:
     theme: flatly
+    include:
+      after_body: footer.html
 params: 
    reporters: params$reporters
    packageName: params$packageName
 ---
+
+<!-- This is HTML code for the header at the top of the page --> 
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+  <a class="navbar-brand" href="http://uptakeopensource.github.io/pkgnet">pkgnet</a>
+</nav>
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = FALSE)
 ```
 
 ```{r title, results="asis"}
-cat(sprintf("# pkgnet: %s", packageName))
+cat(sprintf("# %s", packageName))
 ```
 
 ```{r}

--- a/inst/package_report/package_summary_reporter.Rmd
+++ b/inst/package_report/package_summary_reporter.Rmd
@@ -11,7 +11,7 @@ params:
 This report will give you a high level description of a package
 
 
-```{r}
+```{r comment=NA}
 reporter$get_description()
 ```
 

--- a/inst/package_report/package_summary_reporter.Rmd
+++ b/inst/package_report/package_summary_reporter.Rmd
@@ -11,8 +11,12 @@ params:
 This report will give you a high level description of a package
 
 
-```{r comment=NA}
-reporter$get_description()
+```{r results='asis'}
+DT::datatable(data = reporter$get_description()
+              , rownames = FALSE
+              , options = list(searching = FALSE
+                               , pageLength = 50)
+              )
 ```
 
 ### Num Objects

--- a/inst/package_report/package_summary_reporter.Rmd
+++ b/inst/package_report/package_summary_reporter.Rmd
@@ -15,7 +15,8 @@ This report will give you a high level description of a package
 DT::datatable(data = reporter$get_description()
               , rownames = FALSE
               , options = list(searching = FALSE
-                               , pageLength = 50)
+                               , pageLength = 50
+                               , lengthChange = FALSE)
               )
 ```
 


### PR DESCRIPTION
**Report Format Updates**
1. DT::datatable used to format package description as a table
2. Html header added to report with pkgnet repo link
3. Footer added with license info

**Repo Website Changes**
1. All functions added to reference section (this could use more organization). 
2. Theme changed to "flatly" for no good reason other than to align with report theme.
3. Authors & Contributors and License sections updated. 
