### PR TITLE
Add Node Tables to Report

### DIFF
--- a/R/PackageDependencyReporter.R
+++ b/R/PackageDependencyReporter.R
@@ -157,8 +157,16 @@ PackageDependencyReporter <- R6::R6Class(
         },
         
         get_summary_view = function(){
-          #TODO: DO something with this
-          return(NULL)
+          tableObj <- DT::datatable(
+            data = self$nodes
+            , rownames = FALSE
+            , options = list(
+              searching = FALSE
+              , pageLength = 50
+              , lengthChange = FALSE
+            )
+          )
+          return(tableObj)
         }
         
     ),

--- a/R/PackageFunctionReporter.R
+++ b/R/PackageFunctionReporter.R
@@ -121,8 +121,16 @@ PackageFunctionReporter <- R6::R6Class(
         }, 
         
         get_summary_view = function(){
-          #TODO: DO something with this
-          return(NULL)
+          tableObj <- DT::datatable(
+            data = self$nodes
+            , rownames = FALSE
+            , options = list(
+              searching = FALSE
+              , pageLength = 50
+              , lengthChange = FALSE
+            )
+          )
+          return(tableObj)
         }
     ),
     

--- a/R/PackageSummaryReporter.R
+++ b/R/PackageSummaryReporter.R
@@ -30,6 +30,18 @@ PackageSummaryReporter <- R6::R6Class(
         plot_network = function(){
           # No network in summary reporter
           return(NULL)
+        },
+        get_summary_view = function(){
+          tableObj <- DT::datatable(
+            data = self$get_description()
+            , rownames = FALSE
+            , options = list(
+              searching = FALSE
+              , pageLength = 50
+              , lengthChange = FALSE
+            )
+          )
+          return(tableObj)
         }
     ),
     

--- a/inst/package_report/package_dependency_reporter.Rmd
+++ b/inst/package_report/package_dependency_reporter.Rmd
@@ -7,17 +7,16 @@ params:
 
 ## Dependency Network
 
-### Description
-
-This report will give you a view of what packages you rely on
-
-
-```{r}
-reporter$get_summary_view()
-```
+Here's an overview of of the packages **`r reporter$get_package()`** relies upon.
 
 ### Visualization
 
 ```{r pressure, echo=FALSE}
 reporter$plot_network()
+```
+
+### Table
+
+```{r}
+reporter$get_summary_view()
 ```

--- a/inst/package_report/package_dependency_reporter.Rmd
+++ b/inst/package_report/package_dependency_reporter.Rmd
@@ -13,7 +13,7 @@ This report will give you a view of what packages you rely on
 
 
 ```{r}
-#reporter$get_summary_view()
+reporter$get_summary_view()
 ```
 
 ### Visualization

--- a/inst/package_report/package_function_reporter.Rmd
+++ b/inst/package_report/package_function_reporter.Rmd
@@ -13,7 +13,7 @@ This report provides an overview of the functions defined in your package.
 
 
 ```{r}
-#reporter$get_summary_view()
+reporter$get_summary_view()
 ```
 
 ### Visualization

--- a/inst/package_report/package_function_reporter.Rmd
+++ b/inst/package_report/package_function_reporter.Rmd
@@ -7,17 +7,16 @@ params:
 
 ## Function Network
 
-### Description
-
-This report provides an overview of the functions defined in your package.
-
-
-```{r}
-reporter$get_summary_view()
-```
+Here's an overview of the functions defined in **`r reporter$get_package()`**.
 
 ### Visualization
 
 ```{r echo=FALSE}
 reporter$plot_network()
+```
+
+### Table
+
+```{r}
+reporter$get_summary_view()
 ```

--- a/inst/package_report/package_summary_reporter.Rmd
+++ b/inst/package_report/package_summary_reporter.Rmd
@@ -7,13 +7,7 @@ params:
 
 ## Package Summary
 
-### Description
-
-This report will give you a high level description of a package
-
-```{r results='asis'}
-reporter$get_summary_view()
-```
+Here' some general information about **`r reporter$get_package()`**. 
 
 ### Num Objects
 
@@ -21,4 +15,10 @@ Number of objects
 
 ```{r echo=FALSE}
 reporter$get_objects()
+```
+
+### Table
+
+```{r results='asis'}
+reporter$get_summary_view()
 ```

--- a/inst/package_report/package_summary_reporter.Rmd
+++ b/inst/package_report/package_summary_reporter.Rmd
@@ -12,15 +12,7 @@ params:
 This report will give you a high level description of a package
 
 ```{r results='asis'}
-DT::datatable(
-    data = reporter$get_description()
-    , rownames = FALSE
-    , options = list(
-        searching = FALSE
-        , pageLength = 50
-        , lengthChange = FALSE
-    )
-)
+reporter$get_summary_view()
 ```
 
 ### Num Objects


### PR DESCRIPTION
- Added node tables to the report with `DT`, utilizing `get_summary_view()` functions already established. 
- Slight rearrangement and content changes to report