### PR TITLE
test against packageName and packagePath mismatch.

### DIFF
--- a/R/AbstractPackageReporter.R
+++ b/R/AbstractPackageReporter.R
@@ -70,6 +70,9 @@ AbstractPackageReporter <- R6::R6Class(
             
             if (exists("packagePath") && !is.null(packagePath)) {
                 if (dir.exists(packagePath)) {
+                  if (basename(packagePath) != packageName) {
+                    log_fatal(paste0("The folder name at the end of packagePath does not match packageName."))
+                  }
                     private$packagePath <- packagePath
                 } else {
                     log_fatal(paste0("Package directory does not exist: ", packagePath))

--- a/tests/testthat/test-CreatePackageReport.R
+++ b/tests/testthat/test-CreatePackageReport.R
@@ -34,6 +34,14 @@ test_that("CreatePackageReport rejects bad inputs to reporters", {
             , packageReporters = list(a = rnorm(100))
         )
     }, regexp = "At least one of the reporters passed to CreatePackageReport is not a PackageReporter")
+  
+  expect_error({
+    CreatePackageReport(
+      packageName = "baseballstats"
+      , packagePath = system.file('sartre', package = "pkgnet")
+    )
+  }, regexp = "The folder name at the end of packagePath does not match packageName")
+  
     
 })
 


### PR DESCRIPTION
We either need this test or need to just automatically run coverage if package is available.  

PRO: Easy one-stop-shop.  Less parameters. 
CON: Some packages may take a long time to run tests, and a user may not be interested in coverage.