### PR TITLE
Calculate Test Coverage bug fix

### DIFF
--- a/R/AbstractGraphReporter.R
+++ b/R/AbstractGraphReporter.R
@@ -19,14 +19,14 @@
 #'    \item{\code{network_measures}}{Returns a table of network measures, one row per node}
 #'    \item{\code{graph_viz}}{Returns the graph visualization object}
 #'    \item{\code{orphan_nodes}}{Returns the list of orphan nodes}
-#'    \item{\code{layout_type}}{If no value given, the current layout type for the graph visualization is returned.  
+#'    \item{\code{layout_type}}{If no value given, the current layout type for the graph visualization is returned.
 #'        If a valid layout type is given, this function will update the layout_type field.}
-#'    \item{\code{orphan_node_clustering_threshold}}{If no value given, the current orphan node clustering threshold is returned. 
+#'    \item{\code{orphan_node_clustering_threshold}}{If no value given, the current orphan node clustering threshold is returned.
 #'        If a valid orphan node clustering threshold is given, this function will update the orphan node clustering threshold.}
 #' }
 #' @importFrom data.table data.table copy uniqueN
 #' @importFrom R6 R6Class
-#' @importFrom igraph degree graph_from_edgelist graph.edgelist centralization.betweenness 
+#' @importFrom igraph degree graph_from_edgelist graph.edgelist centralization.betweenness
 #' @importFrom igraph centralization.closeness centralization.degree hub_score
 #' @importFrom igraph layout_as_tree layout_in_circle neighborhood.size page_rank V vcount vertex
 #' @importFrom magrittr %>%
@@ -41,7 +41,6 @@ AbstractGraphReporter <- R6::R6Class(
             if (is.null(private$cache$pkg_graph)){
                 log_info("Creating graph object...")
                 private$make_graph_object()
-                private$calculate_network_measures()
                 log_info("Done creating graph object")
             }
             return(private$cache$pkg_graph)
@@ -49,6 +48,8 @@ AbstractGraphReporter <- R6::R6Class(
         network_measures = function(){
             if (is.null(private$cache$network_measures)){
                 log_info("Calculating network measures...")
+                # Set from NULL to empty list
+                private$cache$network_measures <- list()
                 private$calculate_network_measures()
                 log_info("Done calculating network measures.")
             }
@@ -69,7 +70,7 @@ AbstractGraphReporter <- R6::R6Class(
             return(private$cache$orphan_nodes)
         },
         layout_type = function(value) {
-            
+
             # If the person isn't using <- assignment, return the cached value
             if (!missing(value)) {
                 if (!value %in% names(private$graph_layout_functions)) {
@@ -83,17 +84,17 @@ AbstractGraphReporter <- R6::R6Class(
             return(private$private_layout_type)
         },
         orphan_node_clustering_threshold = function(value) {
-            
+
             # If the person isn't using <- assignment, return the cached value
             if (!missing(value)) {
                 if (class(value) != 'numeric') {
                     log_fatal("orphan_node_clustering_threshold must be numeric.")
                 }
-                
+
                 if (value < 1) {
                     log_fatal("orphan_node_clustering_threshold must at least 1.")
                 }
-                
+
                 # Set new value and reset graph viz
                 if (!is.null(private$cache$graph_viz)) {
                     private$reset_graph_viz()
@@ -103,13 +104,13 @@ AbstractGraphReporter <- R6::R6Class(
             return(private$private_orphan_node_clustering_threshold)
         }
     ),
-    
+
     private = list(
         plotNodeColorScheme = list(
             field = NULL
             , pallete = '#97C2FC'
         ),
-        
+
         # Create a "cache" to be used when evaluating active bindings
         # There is a default cache to reset to
         cache = list(
@@ -120,20 +121,20 @@ AbstractGraphReporter <- R6::R6Class(
             graph_viz = NULL,
             orphan_nodes = NULL
         ),
-        
+
         private_orphan_node_clustering_threshold = 10,
         private_layout_type = "tree",
-        
+
         # Calculate graph-related measures for pkg_graph
         calculate_network_measures = function(){
-            
-            # Create igraph
+
+            # Use igraph object
             pkg_graph <- self$pkg_graph
-            
-            # inital Data.tables
+
+            # Pointer to cached nodes data.table
+            # Note that this is a reference, so changes will update cached table
             outNodeDT <- self$nodes
-            outNetworkList <- list()
-            
+
             #--------------#
             # out degree
             #--------------#
@@ -141,11 +142,11 @@ AbstractGraphReporter <- R6::R6Class(
                 graph = pkg_graph
                 , mode = "out"
             )
-            
+
             # update data.tables
             outNodeDT[, outDegree := outDegreeResult[['res']]] # nodes
-            outNetworkList[['centralization.OutDegree']] <- outDegreeResult$centralization
-            
+            private$cache$network_measures[['centralization.OutDegree']] <- outDegreeResult$centralization
+
             #--------------#
             # betweeness
             #--------------#
@@ -153,11 +154,11 @@ AbstractGraphReporter <- R6::R6Class(
                 graph = pkg_graph
                 , directed = TRUE
             )
-            
+
             # update data.tables
             outNodeDT[, outBetweeness := outBetweenessResult$res] # nodes
-            outNetworkList[['centralization.betweenness']] <- outBetweenessResult$centralization
-            
+            private$cache$network_measures[['centralization.betweenness']] <- outBetweenessResult$centralization
+
             #--------------#
             # closeness
             #--------------#
@@ -167,15 +168,15 @@ AbstractGraphReporter <- R6::R6Class(
                     , mode = "out"
                 )
             })
-            
+
             # update data.tables
             outNodeDT[, outCloseness := outClosenessResult$res] # nodes
-            outNetworkList[['centralization.closeness']] <- outClosenessResult$centralization
-            
+            private$cache$network_measures[['centralization.closeness']] <- outClosenessResult$centralization
+
             #--------------------------------------------------------------#
             # NODE ONLY METRICS
             #--------------------------------------------------------------#
-            
+
             #--------------#
             # Number of Decendants - a.k.a neightborhood or ego
             #--------------#
@@ -184,117 +185,114 @@ AbstractGraphReporter <- R6::R6Class(
                 , order = vcount(pkg_graph)
                 , mode = "out"
             )
-            
+
             # update data.tables
             outNodeDT[, numDescendants := neighborHoodSizeResult] # nodes
-            
+
             #--------------#
-            # Hub Score 
+            # Hub Score
             #--------------#
             hubScoreResult <- igraph::hub_score(
                 graph = pkg_graph
                 , scale = TRUE
             )
             outNodeDT[, hubScore := hubScoreResult$vector] # nodes
-            
+
             #--------------#
             # PageRank
             #--------------#
             pageRankResult <- igraph::page_rank(graph = pkg_graph, directed = TRUE)
             outNodeDT[, pageRank := pageRankResult$vector] # nodes
-            
+
             #--------------#
             # in degree
             #--------------#
             inDegreeResult <- igraph::degree(pkg_graph, mode = "in")
             outNodeDT[, inDegree := inDegreeResult] # nodes
-            
+
             #--------------------------------------------------------------#
             # NETWORK ONLY METRICS
             #--------------------------------------------------------------#
-            
+
             #motifs?
             #knn/assortivity?
-            
-            private$cache$network_measures <- outNetworkList
-            private$cache$nodes <- outNodeDT
-            
+
             return(invisible(NULL))
         },
-        
+
         # Creates pkg_graph igraph object
         # Requires edges and nodes
         make_graph_object = function(){
             edges <- self$edges
             nodes <- self$nodes
-            
+
             if (nrow(edges) > 0) {
-                
+
                 # A graph with edges
                 inGraph <- igraph::graph.edgelist(
                     as.matrix(edges[,list(SOURCE,TARGET)])
                     , directed = TRUE
                 )
-                
+
                 # add isolated nodes
                 allNodes <- nodes$node
                 nonConnectedNodes <- base::setdiff(allNodes, names(igraph::V(inGraph)))
-                
+
                 outGraph <- inGraph + igraph::vertex(nonConnectedNodes)
             } else {
                 # An unconnected graph
                 allNodes <- nodes$node
                 outGraph <- igraph::make_empty_graph() + igraph::vertex(allNodes)
             }
-            
+
             private$cache$pkg_graph <- outGraph
-            
+
             return(invisible(NULL))
         },
-        
-        # Variables for the plot 
+
+        # Variables for the plot
         set_plot_node_color_scheme = function(field
                                               , pallete){
-            
+
             # Check field is length 1 string vector
             if (typeof(field) != "character" || length(field) != 1) {
                 log_fatal(paste0("'field' in set_plot_node_color_scheme must be a string vector of length one. "
                                  , "Coloring by multiple fields not supported."))
             }
-            
+
             # Confirm All Colors in pallete are Colors
             areColors <- function(x) {
                 sapply(x, function(X) {
-                    tryCatch(is.matrix(col2rgb(X)), 
+                    tryCatch(is.matrix(col2rgb(X)),
                              error = function(e) FALSE)
                 })
             }
-            
+
             if (!all(areColors(pallete))) {
                 notColors <- names(areColors)[areColors == FALSE]
                 notColorsTXT <- paste(notColors, collapse = ", ")
                 log_fatal(sprintf("The following are invalid colors: %s"
                                   , notColorsTXT))
             }
-            
+
             private$plotNodeColorScheme <- list(
                 field = field
                 , pallete = pallete
             )
-            
+
             log_info(sprintf("Node color scheme updated: field [%s], pallete [%s]."
                              , private$plotNodeColorScheme[['field']]
                              , paste(private$plotNodeColorScheme[['pallete']], collapse = ",")
             ))
-            
+
             return(invisible(NULL))
         },
-        
+
         # Function to update nodes
         # This function updates the cached nodes data.table, and if it exists, the pkg_graph object
         update_nodes = function(metadataDT) {
             log_info('Updating cached nodes data.table with metadata...')
-            
+
             # Merge new DT with cached DT, but overwrite any colliding columns
             colsToKeep <- setdiff(names(self$nodes), names(metadataDT))
             private$cache$nodes <- merge(x = self$nodes[, .SD, .SDcols = c("node", colsToKeep)]
@@ -303,28 +301,28 @@ AbstractGraphReporter <- R6::R6Class(
                                          , all.x = TRUE)
             return(invisible(NULL))
         },
-        
+
         # Creates visNetwork graph viz object
         # Uses pkg_graph active binding
         plot_network = function(){
-            
+
             log_info("Creating plot...")
-            
+
             # TODO:
             # Open these up to users or remove all the active binding code
             self$layout_type <- "tree"
             self$orphan_node_clustering_threshold <- 10
-            
+
             # format for plot
             plotDTnodes <- data.table::copy(self$nodes) # Don't modify original
             plotDTnodes[, id := node]
             plotDTnodes[, label := id]
-            
+
             log_info(paste("Plotting with layout:", self$layout_type))
             plotDTnodes <- private$calculate_graph_layout(
                 plotDT = plotDTnodes
             )
-            
+
             if (length(self$edges) > 0) {
                 plotDTedges <- data.table::copy(self$edges) # Don't modify original
                 plotDTedges[, from := SOURCE]
@@ -333,18 +331,18 @@ AbstractGraphReporter <- R6::R6Class(
             } else {
                 plotDTedges <- NULL
             }
-            
+
             # Color By Field
             if (is.null(private$plotNodeColorScheme[['field']])) {
-                
+
                 # Default Color for all Nodes
                 plotDTnodes[, color := private$plotNodeColorScheme[['pallete']]]
-                
+
             } else {
-                
+
                 # Fetch Color Scheme Values
                 colorFieldName <- private$plotNodeColorScheme[['field']]
-                
+
                 # Check that that column exists in nodes table
                 if (!is.element(colorFieldName, names(self$nodes))) {
                     log_fatal(sprintf(paste0("'%s' is not a field in the nodes table",
@@ -352,38 +350,38 @@ AbstractGraphReporter <- R6::R6Class(
                                       , private$plotNodeColorScheme[['field']])
                     )
                 }
-                
+
                 colorFieldPallete <- private$plotNodeColorScheme[['pallete']]
                 colorFieldValues <- plotDTnodes[[colorFieldName]]
                 log_info(sprintf("Coloring plot nodes by %s..."
                                  , colorFieldName))
-                
-                # If colorFieldValues are character 
+
+                # If colorFieldValues are character
                 if (is.character(colorFieldValues) | is.factor(colorFieldValues)) {
-                    
+
                     # Create pallete by unique values
                     valCount <- data.table::uniqueN(colorFieldValues)
                     newPallete <- grDevices::colorRampPalette(colors = colorFieldPallete)(valCount)
-                    
+
                     # For each character value, update all nodes with that value
                     plotDTnodes[, color := newPallete[.GRP]
                                 , by = list(get(colorFieldName))]
-                    
+
                 } else if (is.numeric(colorFieldValues)) {
                     # If colorFieldValues are numeric, assume continuous
-                    
+
                     # Create Continuous Color Pallete
                     newPallete <- grDevices::colorRamp(colors = colorFieldPallete)
-                    
+
                     # Scale Values to be with range 0 - 1
                     plotDTnodes[!is.na(get(colorFieldName)), scaledColorValues := get(colorFieldName) / max(get(colorFieldName))]
-                    
+
                     # Assign Color Values From Pallete
                     plotDTnodes[!is.na(scaledColorValues), color := grDevices::rgb(newPallete(scaledColorValues), maxColorValue = 255)]
-                    
+
                     # NA Values get gray color
                     plotDTnodes[is.na(scaledColorValues), color := "gray"]
-                    
+
                 } else {
                     # Error Out
                     log_fatal(sprintf(paste0("A character, factor, or numeric field can be used to color nodes. "
@@ -392,11 +390,11 @@ AbstractGraphReporter <- R6::R6Class(
                                       , typeof(colorFieldValues)
                     )
                     )
-                    
+
                 } # end non-default color field
-                
+
             } # end color field creation
-            
+
             # If threshold to group orphan nodes, then assign group
             numOrphanNodes <- length(self$orphanNodes)
             numOrphanThreshold <- self$orphan_node_clustering_threshold
@@ -410,7 +408,7 @@ AbstractGraphReporter <- R6::R6Class(
                 plotDTnodes[, group := NA_character_]
                 plotDTnodes[node %in% self$orphan_nodes, group := "orphan"]
             }
-            
+
             # Create Plot
             g <- visNetwork::visNetwork(nodes = plotDTnodes
                                         , edges = plotDTedges) %>%
@@ -420,27 +418,27 @@ AbstractGraphReporter <- R6::R6Class(
                 visNetwork::visOptions(highlightNearest = list(enabled = TRUE
                                                                , degree = nrow(plotDTnodes) #guarantee full path
                                                                , algorithm = "hierarchical"))
-            
+
             # Add orphan node clustering
             if (numOrphanNodes > numOrphanThreshold) {
                 g <- g %>% visNetwork::visClusteringByGroup(groups = c("orphan"))
             }
-            
+
             log_info("Done creating plot.")
-            
+
             # Save plot in the cache
             private$cache$graph_viz <- g
-            
+
             return(g)
         },
-        
+
         # Function to reset cached graph_viz
         reset_graph_viz = function() {
             log_info('Resetting cached graph_viz...')
             private$cache$graph_viz <- NULL
             return(invisible(NULL))
         },
-        
+
         # Identify orphan nodes
         identify_orphan_nodes = function() {
             orphan_nodes <- base::setdiff(self$nodes[, node]
@@ -449,20 +447,20 @@ AbstractGraphReporter <- R6::R6Class(
             # If there are none, then will be character(0)
             return(orphan_nodes)
         },
-        
+
         graph_layout_functions = list(
             "tree" = function(pkg_graph) {igraph::layout_as_tree(pkg_graph)},
             "circle" = function(pkg_graph) {igraph::layout_in_circle(pkg_graph)}
         ),
-        
+
         calculate_graph_layout = function(plotDT) {
-            
+
             log_info(paste("Calculating graph layout for type:", self$layout_type))
-            
+
             # Calculate positions for specified layout_type
             graph_func <- private$graph_layout_functions[[self$layout_type]]
             plotMat <- graph_func(self$pkg_graph)
-            
+
             # It might be important to get the nodes from pkg_graph so that they
             # are in the same order as in plotMat?
             coordsDT <- data.table::data.table(
@@ -470,10 +468,10 @@ AbstractGraphReporter <- R6::R6Class(
                 , level = plotMat[, 2]
                 , horizontal = plotMat[, 1]
             )
-            
+
             # Merge coordinates with plotDT
             plotDT <- merge(plotDT, coordsDT, by = 'node', all.x = TRUE)
-            
+
             return(plotDT)
         }
     )

--- a/R/PackageDependencyReporter.R
+++ b/R/PackageDependencyReporter.R
@@ -44,20 +44,26 @@ DependencyReporter <- R6::R6Class(
         },
 
         get_summary_view = function(){
-          tableObj <- DT::datatable(
-            data = self$nodes
-            , rownames = FALSE
-            , options = list(
-              searching = FALSE
-              , pageLength = 50
-              , lengthChange = FALSE
+            
+            # Calculate network measures if not already done
+            # since we want the node measures in summary
+            invisible(self$network_measures)
+            
+            # Create DT for display
+            tableObj <- DT::datatable(
+                data = self$nodes
+                , rownames = FALSE
+                , options = list(
+                    searching = FALSE
+                    , pageLength = 50
+                    , lengthChange = FALSE
+                )
             )
-          )
-          # Round the double columns to three digits for formatting reasons
-          numCols <- names(which(unlist(lapply(tableObj$x$data, is.double))))
-          tableObj <- DT::formatRound(columns = numCols, table = tableObj
-                                      , digits=3)
-          return(tableObj)
+            # Round the double columns to three digits for formatting reasons
+            numCols <- names(which(unlist(lapply(tableObj$x$data, is.double))))
+            tableObj <- DT::formatRound(columns = numCols, table = tableObj
+                                        , digits=3)
+            return(tableObj)
         }
 
     ),

--- a/R/PackageFunctionReporter.R
+++ b/R/PackageFunctionReporter.R
@@ -33,20 +33,26 @@ FunctionReporter <- R6::R6Class(
 
     public = list(
         get_summary_view = function(){
-          tableObj <- DT::datatable(
-            data = self$nodes
-            , rownames = FALSE
-            , options = list(
-              searching = FALSE
-              , pageLength = 50
-              , lengthChange = FALSE
+            
+            # Calculate network measures if not already done
+            # since we want the node measures in summary
+            invisible(self$network_measures)
+            
+            # Create DT for display
+            tableObj <- DT::datatable(
+                data = self$nodes
+                , rownames = FALSE
+                , options = list(
+                    searching = FALSE
+                    , pageLength = 50
+                    , lengthChange = FALSE
+                )
             )
-          )
-          # Round the double columns to three digits for formatting reasons
-          numCols <- names(which(unlist(lapply(tableObj$x$data, is.double))))
-          tableObj <- DT::formatRound(columns = numCols, table = tableObj
-                                      , digits=3)
-          return(tableObj)
+            # Round the double columns to three digits for formatting reasons
+            numCols <- names(which(unlist(lapply(tableObj$x$data, is.double))))
+            tableObj <- DT::formatRound(columns = numCols, table = tableObj
+                                        , digits=3)
+            return(tableObj)
         }
     ),
 


### PR DESCRIPTION
Fixes #84.

- Removed a bunch of unneeded explicit `calculate_network_measure` calls.
- `calculate_network_measures` inserts into cached `network_measures` list instead of overwriting. 