### PR TITLE
Add more informative error on bad package name specification

### DIFF
--- a/R/AbstractPackageReporter.R
+++ b/R/AbstractPackageReporter.R
@@ -6,6 +6,7 @@
 #'              overloaded such that each Metric implements certain functionality.
 #' @importFrom R6 R6Class
 #' @importFrom tools file_path_as_absolute
+#' @importFrom utils installed.packages
 #' @section Public Methods:
 #' \describe{
 #'     \item{\code{set_package(pkg_name, pkg_path = NULL)}}{
@@ -35,6 +36,13 @@ AbstractPackageReporter <- R6::R6Class(
     public = list(
         
         set_package = function(pkg_name, pkg_path = NULL) {
+            
+            # check inputs
+            assertthat::assert_that(
+                assertthat::is.string(pkg_name)
+                , pkg_name != ""
+            )
+            private$validate_pkg_name(pkg_name)
             
             private$private_pkg_name <- pkg_name
             
@@ -82,6 +90,23 @@ AbstractPackageReporter <- R6::R6Class(
                     private$cache[[item]] <- NULL
                 }
             }
+            return(invisible(NULL))
+        },
+        
+        # given a string with a package name, check whether
+        # it exists
+        validate_pkg_name = function(pkg_name){
+            log_info("Checking installed packages...")
+            installed_packages <- row.names(
+                utils::installed.packages()
+            )
+            
+            if (! pkg_name %in% installed_packages){
+                msg <- sprintf("pkgnet could not find a package called '%s'.", pkg_name)
+                log_fatal(msg)
+            }
+            
+            log_info(sprintf("Found '%s' in installed packages.", pkg_name))
             return(invisible(NULL))
         }
     )

--- a/R/CreatePackageReport.R
+++ b/R/CreatePackageReport.R
@@ -12,6 +12,7 @@
 #'                   report will be produced in the temporary directory.
 #' @importFrom assertthat assert_that is.string
 #' @importFrom methods is
+#' @importFrom tools file_path_as_absolute
 #' @importFrom utils browseURL
 #' @return A list of instantiated pkg_reporters fitted to \code{pkg_name}
 #' @export

--- a/tests/testthat/test-AbstractPackageReporter.R
+++ b/tests/testthat/test-AbstractPackageReporter.R
@@ -38,6 +38,14 @@ test_that('AbstractPackageReporter structure is as expected', {
   
 })
 
+
+test_that("AbstractPackageReporter rejects bad packages with an informative error", {
+    expect_error({
+        x <- AbstractPackageReporter$new()
+        x$set_package("w0uldNEverB33aPackageName")
+    }, regexp = "pkgnet could not find a package called 'w0uldNEverB33aPackageName'")
+})
+
 ### USAGE OF PUBLIC AND PRIVATE METHODS AND FIELDS TO BE TESTED BY CHILD OBJECTS
 
 ##### TEST TEAR DOWN #####

--- a/tests/testthat/test-CreatePackageReport.R
+++ b/tests/testthat/test-CreatePackageReport.R
@@ -40,6 +40,14 @@ test_that("CreatePackageReport rejects bad inputs to reporters", {
     
 })
 
+test_that("CreatePackageReport rejects bad packages with an informative error", {
+    expect_error({
+        CreatePackageReport(
+            pkg_name = "w0uldNEverB33aPackageName"
+        )
+    }, regexp = "pkgnet could not find a package called 'w0uldNEverB33aPackageName'")
+})
+
 
 ##### TEST TEAR DOWN #####
 

--- a/tests/testthat/test-DependencyReporter.R
+++ b/tests/testthat/test-DependencyReporter.R
@@ -113,6 +113,17 @@ test_that('DependencyReporter Methods Work', {
     )
 })
 
+
+test_that("DependencyReporter rejects bad packages with an informative error", {
+    expect_error({
+        testObj <- DependencyReporter$new()
+        testObj$set_package(
+            pkg_name = "w0uldNEverB33aPackageName"
+        )
+    }, regexp = "pkgnet could not find a package called 'w0uldNEverB33aPackageName'")
+})
+
+
 ##### TEST TEAR DOWN #####
 
 futile.logger::flog.threshold(origLogThreshold)

--- a/tests/testthat/test-FunctionReporter.R
+++ b/tests/testthat/test-FunctionReporter.R
@@ -130,6 +130,16 @@ test_that('FunctionReporter Methods Work', {
 })
 
 
+test_that("FunctionReporter rejects bad packages with an informative error", {
+    expect_error({
+        testObj <- FunctionReporter$new()
+        testObj$set_package(
+            pkg_name = "w0uldNEverB33aPackageName"
+        )
+    }, regexp = "pkgnet could not find a package called 'w0uldNEverB33aPackageName'")
+})
+
+
 ##### TEST TEAR DOWN #####
 
 futile.logger::flog.threshold(origLogThreshold)


### PR DESCRIPTION
This PR tries to address #89 , adding a faster and more informative error for the case where someone tries to use a package that isn't locally installed.

I do not think `pkgnet` should take any responsibility for polling CRAN (to see if a package theoretically _might_ exist) or trying an installation directly. I also do not think it should expose the ability to set a custom library location.

We should just fail if a package isn't found in the default `lib.loc`.

