### PR TITLE
Change default dep_types for DependencyReporter to include Depends

### DIFF
--- a/R/PackageDependencyReporter.R
+++ b/R/PackageDependencyReporter.R
@@ -30,11 +30,11 @@ DependencyReporter <- R6::R6Class(
 
     public = list(
 
-        initialize = function(dep_types = "Imports", installed = TRUE){
+        initialize = function(dep_types = c("Imports", "Depends"), installed = TRUE){
 
             # Check inputs
             assertthat::assert_that(
-                assertthat::is.string(dep_types)
+                is.character(dep_types)
                 , assertthat::is.flag(installed)
             )
 
@@ -176,8 +176,14 @@ DependencyReporter <- R6::R6Class(
             private$cache$edges <- edges
 
             # Get and save nodes
-            nodes <- data.table::data.table(node = unique(c(self$edges[, SOURCE]
-                                                            , self$edges[, TARGET])))
+            nodes <- data.table::data.table(
+                node = unique(
+                    c(
+                        self$edges[, SOURCE]
+                        , self$edges[, TARGET]
+                      )
+                )
+            )
             private$cache$nodes <- nodes
 
             return(invisible(NULL))

--- a/man/AbstractGraphReporter.Rd
+++ b/man/AbstractGraphReporter.Rd
@@ -32,9 +32,9 @@ Defines the Abstract Class for all PackageGraphReporters defined in pkgnet.
    \item{\code{network_measures}}{Returns a table of network measures, one row per node}
    \item{\code{graph_viz}}{Returns the graph visualization object}
    \item{\code{orphan_nodes}}{Returns the list of orphan nodes}
-   \item{\code{layout_type}}{If no value given, the current layout type for the graph visualization is returned.  
+   \item{\code{layout_type}}{If no value given, the current layout type for the graph visualization is returned.
        If a valid layout type is given, this function will update the layout_type field.}
-   \item{\code{orphan_node_clustering_threshold}}{If no value given, the current orphan node clustering threshold is returned. 
+   \item{\code{orphan_node_clustering_threshold}}{If no value given, the current orphan node clustering threshold is returned.
        If a valid orphan node clustering threshold is given, this function will update the orphan node clustering threshold.}
 }
 }

--- a/man/FunctionReporter.Rd
+++ b/man/FunctionReporter.Rd
@@ -10,7 +10,7 @@ FunctionReporter
 }
 \description{
 This Reporter takes a package and uncovers the structure from
-             its other functions, determining useful information such as which function is most 
+             its other functions, determining useful information such as which function is most
              central to the package. Combined with testing information it can be used as a powerful tool
              to plan testing efforts.
 }
@@ -19,7 +19,7 @@ This Reporter takes a package and uncovers the structure from
 \describe{
     \item{\code{set_package(pkg_name, pkg_path)}}{
         \itemize{
-            \item{Set properties of this reporter. If pkg_name overrides a 
+            \item{Set properties of this reporter. If pkg_name overrides a
                 previously-set package name, any cached data will be removed.}
             \item{\bold{Args:}}{
                 \itemize{


### PR DESCRIPTION
`Depends` is the strong form of package dependency and we should make it a default in `DependencyReporter`. See discussion in #95 for more details.

This will make `pkgnet` work for some of the older R packages on CRAN which still have all of their dependencies declared in Depends, such as [gbm](https://cran.r-project.org/web/packages/gbm/index.html).

Example code to test that this worked:

**fails (current state of master)**

```r
reporter <- DependencyReporter$new(
    , dep_types = c("Imports")
)
reporter$set_package("gbm")
reporter$graph_viz
```

**works on this branch**

```r
reporter <- DependencyReporter$new(
    , dep_types = c("Imports", "Depends")
)
reporter$set_package("gbm")
reporter$graph_viz
```

many thanks to @ShirinG for reporting this issue in [her R-bloggers post](https://www.r-bloggers.com/comparing-dependencies-of-popular-machine-learning-packages-with-pkgnet/).