### PR TITLE
Add more explicit handling for empty graphs

### DIFF
--- a/R/AbstractGraphReporter.R
+++ b/R/AbstractGraphReporter.R
@@ -263,8 +263,11 @@ AbstractGraphReporter <- R6::R6Class(
             # Confirm All Colors in pallete are Colors
             areColors <- function(x) {
                 sapply(x, function(X) {
-                    tryCatch(is.matrix(col2rgb(X)),
-                             error = function(e) FALSE)
+                    tryCatch({
+                        is.matrix(col2rgb(X))
+                    }, error = function(e){
+                        FALSE
+                    })
                 })
             }
 
@@ -295,10 +298,12 @@ AbstractGraphReporter <- R6::R6Class(
 
             # Merge new DT with cached DT, but overwrite any colliding columns
             colsToKeep <- setdiff(names(self$nodes), names(metadataDT))
-            private$cache$nodes <- merge(x = self$nodes[, .SD, .SDcols = c("node", colsToKeep)]
-                                         , y = metadataDT
-                                         , by = "node"
-                                         , all.x = TRUE)
+            private$cache$nodes <- merge(
+                x = self$nodes[, .SD, .SDcols = c("node", colsToKeep)]
+                , y = metadataDT
+                , by = "node"
+                , all.x = TRUE
+            )
             return(invisible(NULL))
         },
 
@@ -416,7 +421,7 @@ AbstractGraphReporter <- R6::R6Class(
                                                   , direction = "UD") %>%
                 visNetwork::visEdges(arrows = 'to') %>%
                 visNetwork::visOptions(highlightNearest = list(enabled = TRUE
-                                                               , degree = nrow(plotDTnodes) #guarantee full path
+                                                               , degree = nrow(plotDTnodes) # guarantee full path
                                                                , algorithm = "hierarchical"))
 
             # Add orphan node clustering
@@ -441,9 +446,11 @@ AbstractGraphReporter <- R6::R6Class(
 
         # Identify orphan nodes
         identify_orphan_nodes = function() {
-            orphan_nodes <- base::setdiff(self$nodes[, node]
-                                         , unique(c(self$edges[, SOURCE], self$edges[, TARGET]))
-                                        )
+            orphan_nodes <- base::setdiff(
+                self$nodes[, node]
+                , unique(c(self$edges[, SOURCE], self$edges[, TARGET]))
+            )
+            
             # If there are none, then will be character(0)
             return(orphan_nodes)
         },
@@ -470,7 +477,12 @@ AbstractGraphReporter <- R6::R6Class(
             )
 
             # Merge coordinates with plotDT
-            plotDT <- merge(plotDT, coordsDT, by = 'node', all.x = TRUE)
+            plotDT <- merge(
+                x = plotDT
+                , y = coordsDT
+                , by = 'node'
+                , all.x = TRUE
+            )
 
             return(plotDT)
         }

--- a/R/PackageDependencyReporter.R
+++ b/R/PackageDependencyReporter.R
@@ -162,6 +162,15 @@ DependencyReporter <- R6::R6Class(
             }
 
             dependencyList <- Filter(function(x){!is.null(x)}, dependencyList)
+            
+            if (identical(names(dependencyList), self$pkg_name)){
+                msg <- paste0(
+                    "Package '%s' does not have any dependencies in [%s]. If you think this is an error ", 
+                    "consider adding more dependency types in your definition of DependencyReporter. ",
+                    "For example: DependencyReporter$new(dep_types = c('Imports', 'Depends', 'Suggests'))"
+                )
+                log_fatal(sprintf(msg, self$pkg_name, paste(private$dep_types, collapse = ", ")))
+            }
 
             edges <- data.table::rbindlist(lapply(
                 names(dependencyList),
@@ -181,7 +190,7 @@ DependencyReporter <- R6::R6Class(
                     c(
                         self$edges[, SOURCE]
                         , self$edges[, TARGET]
-                      )
+                     )
                 )
             )
             private$cache$nodes <- nodes

--- a/R/PackageFunctionReporter.R
+++ b/R/PackageFunctionReporter.R
@@ -151,7 +151,9 @@ FunctionReporter <- R6::R6Class(
             if (is.null(self$pkg_name)) {
                 log_fatal('Must set_package() before extracting nodes.')
             }
-            nodes <- data.table::data.table(node = as.character(unlist(utils::lsf.str(asNamespace(self$pkg_name)))))
+            nodes <- data.table::data.table(
+                node = as.character(unlist(utils::lsf.str(asNamespace(self$pkg_name))))
+            )
             return(nodes)
         },
 

--- a/inst/package_report/package_dependency_reporter.Rmd
+++ b/inst/package_report/package_dependency_reporter.Rmd
@@ -6,11 +6,20 @@ Here's an overview of of the packages **`r reporter$pkg_name`** relies upon.
 ### Visualization
 
 ```{r pressure, echo=FALSE}
-reporter$graph_viz
+result <- tryCatch({
+    reporter$graph_viz
+}, error = function(e){
+    return(sprintf("DependencyReporter failed with error -->     %s", e$message))
+})
+result
 ```
 
 ### Table
 
 ```{r}
-reporter$get_summary_view()
+result <- tryCatch({
+    reporter$get_summary_view()
+}, error = function(e){
+    return(sprintf("DependencyReporter failed with error %s", e$message))
+})
 ```

--- a/inst/package_report/package_report.Rmd
+++ b/inst/package_report/package_report.Rmd
@@ -13,11 +13,11 @@ params:
 ---
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = FALSE)
+knitr::opts_chunk$set(echo = FALSE, warning=FALSE)
 pkgnet:::silence_logger()
 ```
 
-```{r}
+```{r warning=FALSE}
 reportTabs <- lapply(params$reporters, function(reporter) {
   report_env <- list2env(list(reporter = reporter))
   knitr::knit_child(

--- a/tests/testthat/test-DependencyReporter.R
+++ b/tests/testthat/test-DependencyReporter.R
@@ -124,6 +124,14 @@ test_that("DependencyReporter rejects bad packages with an informative error", {
 })
 
 
+test_that("DependencyReporter should break with an informative error for packages with no deps", {
+    expect_error({
+        reporter <- DependencyReporter$new()
+        reporter$set_package("base")
+        reporter$graph_viz
+    }, regexp = "consider adding more dependency types in your definition of DependencyReporter")
+})
+
 ##### TEST TEAR DOWN #####
 
 futile.logger::flog.threshold(origLogThreshold)


### PR DESCRIPTION
This is the second of 2 PRs addressing #95 . It is possible for `DependencyReporter` to generate an empty graph if you try with a package that has no dependencies (`'base'`) or you don't specify enough dependency types to check (see discussion in #95 on how `gbm` uses only `Depends`).

My philosophy was to have `DependencyReporter` throw a fatal error, but still have `CreatePackageReport` work. I strongly believe that `CreatePackageReport` should always work even if some of the boxes get filled in with errors or are left empty.