### PR TITLE
FunctionReporter to handle Non-exported Functions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,5 @@ CONDUCT.md
 CONTRIBUTING.md
 .travis.yml
 ^_pkgdown\.yml$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 # Misc files
 .Rhistory
+*.Rproj
 tests/testthat/Rplots.pdf
 **/.DS_Store
 
@@ -12,3 +13,4 @@ tests/testthat/Rplots.pdf
 # build artifacts
 **/*.tar.gz
 pkgnet.Rcheck/*
+.Rproj.user

--- a/R/PackageFunctionReporter.R
+++ b/R/PackageFunctionReporter.R
@@ -249,10 +249,14 @@ FunctionReporter <- R6::R6Class(
     if (length(matches) == 0){
         return(invisible(NULL))
     }
-
+    
+    # Convention: If B depends on A, then B is the TARGET 
+    # and A is the SOURCE so that it looks like A -> B
+    # fname calls <matches>. So fname depends on <matches>.
+    # So fname is TARGET and <matches> are SOURCEs
     edgeDT <- data.table::data.table(
-        SOURCE = fname
-        , TARGET = unique(all_functions[matches])
+        SOURCE = unique(all_functions[matches])
+        , TARGET = fname
     )
 
     return(edgeDT)

--- a/R/PackageFunctionReporter.R
+++ b/R/PackageFunctionReporter.R
@@ -23,7 +23,7 @@
 #'     }
 #' }
 #' @importFrom covr package_coverage
-#' @importFrom data.table data.table melt as.data.table data.table setnames setcolorder
+#' @importFrom data.table data.table melt as.data.table data.table setnames setcolorder rbindlist
 #' @importFrom DT datatable formatRound
 #' @importFrom R6 R6Class
 #' @importFrom utils lsf.str
@@ -130,14 +130,14 @@ FunctionReporter <- R6::R6Class(
         extract_network = function(){
             # Reset cache, because any cached stuff will be outdated with a new network
             private$reset_cache()
-
-            log_info(sprintf('Extracting edges from %s...', self$pkg_name))
-            private$cache$edges <- private$extract_edges()
-            log_info('Done extracting edges.')
-
+            
             log_info(sprintf('Extracting nodes from %s...', self$pkg_name))
             private$cache$nodes <- private$extract_nodes()
             log_info('Done extracting nodes.')
+            
+            log_info(sprintf('Extracting edges from %s...', self$pkg_name))
+            private$cache$edges <- private$extract_edges()
+            log_info('Done extracting edges.')
 
             # TODO (james.lamb@uptake.com):
             # Make this handoff with coverage cleaner
@@ -152,12 +152,25 @@ FunctionReporter <- R6::R6Class(
             if (is.null(self$pkg_name)) {
                 log_fatal('Must set_package() before extracting nodes.')
             }
-            nodes <- data.table::data.table(node = as.character(
-                unlist(
-                    utils::lsf.str(pos = asNamespace(self$pkg_name))
-                    )
-                )
+            
+            # create a custom environment w/ this package's contents
+            pkg_env <- loadNamespace(self$pkg_name)
+            
+            # Filter objects to just functions
+            # This will now be a character vector full of function names
+            funs <- Filter(
+                f = function(x, p = pkg_env){is.function(get(x, p))}
+                , x = names(pkg_env)
             )
+            
+            # Create nodes data.table
+            nodes <- data.table::data.table(node = funs)
+            
+            # Figure out which functions are exported
+            exported_obj_names <- ls(sprintf("package:%s", self$pkg_name))
+            nodes[, isExported := FALSE]
+            nodes[node %in% exported_obj_names, isExported := TRUE]
+            
             return(nodes)
         },
 
@@ -166,25 +179,34 @@ FunctionReporter <- R6::R6Class(
                 log_fatal('Must set_package() before extracting edges.')
             }
 
-            log_info(sprintf('Loading %s...', self$pkg_name))
-            suppressPackageStartupMessages({
-                require(self$pkg_name
-                        , lib.loc = .libPaths()[1]
-                        , character.only = TRUE)
-            })
-            log_info(sprintf('Done loading %s', self$pkg_name))
-
-            # Avoid mvbutils::foodweb bug on one function packages
-            numFuncs <- as.character(unlist(utils::lsf.str(asNamespace(self$pkg_name)))) # list of functions within Package
-            if (length(numFuncs) == 1) {
-                log_info("Only one function. Edge list is empty")
-                return(data.table::data.table(SOURCE = character(), TARGET = character()))
-            }
-
             log_info(sprintf('Constructing network representation...'))
-
+            
+            # create a custom environment w/ this package's contents
+            pkg_env <- loadNamespace(self$pkg_name)
+            
             # Get table of edges between functions
-            edgeDT <- .get_function_graph_edges(pkg_name = self$pkg_name)
+            # for each function, check if anything else in the package
+            # was called by it
+            funs <- self$nodes[, node]
+            edgeDT <- data.table::rbindlist(
+                lapply(
+                    X = funs
+                    , FUN = .called_by
+                    , all_functions = funs
+                    , pkg_env = pkg_env
+                )
+                , fill = TRUE
+            )
+            
+            # If there are no edges, we still want to return a length-zero 
+            # data.table with correct columns
+            if (nrow(edgeDT) == 0) {
+                log_info("Edge list is empty.")
+                edgeDT <- data.table::data.table(
+                                SOURCE = character()
+                                , TARGET = character()
+                            )
+            }
 
             log_info("Done constructing network representation")
 
@@ -192,36 +214,6 @@ FunctionReporter <- R6::R6Class(
         }
     )
 )
-
-#' @importFrom data.table rbindlist
-.get_function_graph_edges <- function(pkg_name){
-
-    # find all functions in this package
-    obj_names <- ls(sprintf("package:%s", pkg_name))
-
-    # create a custom environment w/ this package's contents
-    pkg_env <- loadNamespace(pkg_name)
-
-    # Filter to just function objects. This will now be a character
-    # vector full of function names
-    funs <- Filter(
-        f = function(x, p = pkg_env){is.function(get(x, p))}
-        , x = obj_names
-    )
-
-    # for each function, check if anything else in the package
-    # was called by it
-    edgeDT <- data.table::rbindlist(
-        lapply(
-            X = funs
-            , FUN = .called_by
-            , all_functions = funs
-            , pkg_env = pkg_env
-        )
-        , fill = TRUE
-    )
-}
-
 
 # [description] given a function name, return edgelist of
 #               all other functions it calls

--- a/R/PackageFunctionReporter.R
+++ b/R/PackageFunctionReporter.R
@@ -174,9 +174,8 @@ FunctionReporter <- R6::R6Class(
                         , character.only = TRUE)
             })
             exported_obj_names <- ls(sprintf("package:%s", self$pkg_name))
-            nodes[, isExported := FALSE]
-            nodes[node %in% exported_obj_names, isExported := TRUE]
-            
+            nodes[, isExported := node %in% exported_obj_names]
+
             return(nodes)
         },
 

--- a/R/PackageFunctionReporter.R
+++ b/R/PackageFunctionReporter.R
@@ -167,6 +167,12 @@ FunctionReporter <- R6::R6Class(
             nodes <- data.table::data.table(node = funs)
             
             # Figure out which functions are exported
+            # We need the package to be loaded first
+            suppressPackageStartupMessages({
+                require(self$pkg_name
+                        , lib.loc = .libPaths()[1]
+                        , character.only = TRUE)
+            })
             exported_obj_names <- ls(sprintf("package:%s", self$pkg_name))
             nodes[, isExported := FALSE]
             nodes[node %in% exported_obj_names, isExported := TRUE]

--- a/tests/testthat/test-DependencyReporter.R
+++ b/tests/testthat/test-DependencyReporter.R
@@ -6,9 +6,9 @@ rm(list = ls())
 # Configure logger (suppress all logs in testing)
 loggerOptions <- futile.logger::logger.options()
 if (!identical(loggerOptions, list())){
-  origLogThreshold <- loggerOptions[[1]][['threshold']]
+    origLogThreshold <- loggerOptions[[1]][['threshold']]
 } else {
-  origLogThreshold <- futile.logger::INFO
+    origLogThreshold <- futile.logger::INFO
 }
 futile.logger::flog.threshold(0)
 
@@ -17,109 +17,109 @@ futile.logger::flog.threshold(0)
 ## Structure Available ##
 
 test_that('DependencyReporter structure is as expected', {
-
-  expect_named(object = DependencyReporter$public_methods
-               , expected = c(
-                 "get_summary_view",
-                 "initialize",
-                 "clone"
-               )
-               , info = "Available public methods for DependencyReporter not as expected."
-               , ignore.order = TRUE
-               , ignore.case = FALSE
-  )
-
-  expect_named(object = DependencyReporter$public_fields
-               , expected = NULL
-               , info = "Available public fields for DependencyReporter not as expected."
-               , ignore.order = TRUE
-               , ignore.case = FALSE
-  )
-
+    
+    expect_named(object = DependencyReporter$public_methods
+                 , expected = c(
+                     "get_summary_view",
+                     "initialize",
+                     "clone"
+                 )
+                 , info = "Available public methods for DependencyReporter not as expected."
+                 , ignore.order = TRUE
+                 , ignore.case = FALSE
+    )
+    
+    expect_named(object = DependencyReporter$public_fields
+                 , expected = NULL
+                 , info = "Available public fields for DependencyReporter not as expected."
+                 , ignore.order = TRUE
+                 , ignore.case = FALSE
+    )
+    
 })
 
 ### USAGE OF PUBLIC AND PRIVATE METHODS AND FIELDS
 
 test_that('DependencyReporter Methods Work', {
-  testObj <- DependencyReporter$new()
-
-  # inherited set_package
-  expect_silent({
-
-      # testing set_package with a pkg_path that is relative to the current directory
-      entry_wd <- getwd()
-      baseball_dir <- system.file(
-          'baseballstats'
-          , package='pkgnet'
-          , lib.loc = Sys.getenv('PKGNET_TEST_LIB')
-      )
-      parent_dir <- dirname(baseball_dir)
-      setwd(parent_dir)
-
-      testObj$set_package(
-          pkg_name = "baseballstats"
-          , pkg_path = 'baseballstats'
-      )
-      setwd(entry_wd)
-  })
-
-  # Sometimes with R CMD CHECK the temp dir begins /private/vars. Other times, just /vars.
-  # Also, sometimes there are double slashes.
-  fmtPath <- function(path){
-      out <- gsub('^/private', '', path)
-      out <- gsub('//', '/', out)
-      out <- tools::file_path_as_absolute(out)
-      return(out)
-  }
-
-  expect_identical(
+    testObj <- DependencyReporter$new()
+    
+    # inherited set_package
+    expect_silent({
+        
+        # testing set_package with a pkg_path that is relative to the current directory
+        entry_wd <- getwd()
+        baseball_dir <- system.file(
+            'baseballstats'
+            , package='pkgnet'
+            , lib.loc = Sys.getenv('PKGNET_TEST_LIB')
+        )
+        parent_dir <- dirname(baseball_dir)
+        setwd(parent_dir)
+        
+        testObj$set_package(
+            pkg_name = "baseballstats"
+            , pkg_path = 'baseballstats'
+        )
+        setwd(entry_wd)
+    })
+    
+    # Sometimes with R CMD CHECK the temp dir begins /private/vars. Other times, just /vars.
+    # Also, sometimes there are double slashes.
+    fmtPath <- function(path){
+        out <- gsub('^/private', '', path)
+        out <- gsub('//', '/', out)
+        out <- tools::file_path_as_absolute(out)
+        return(out)
+    }
+    
+    expect_identical(
         object = fmtPath(testObj$.__enclos_env__$private$pkg_path)
-      , expected = fmtPath(baseball_dir)
-      , info = "set_package did not use the absolute path of the directory"
-  )
-
-  # "extract_network"
-  expect_silent({
-      testObj$.__enclos_env__$private$extract_network()
-  })
-
-  expect_named(
-      object = testObj$edges
-      , expected = c("SOURCE", "TARGET")
-      , info = "more than edges created by extract_network"
-      , ignore.order = FALSE # enforcing this convention
-      , ignore.case = FALSE
-  )
-
-  expect_true(object = all(testObj$edges[,unique(c(SOURCE, TARGET))] %in% c("base",
-                                                                            "methods",
-                                                                            "utils",
-                                                                            "stats",
-                                                                            "grDevices",
-                                                                            "graphics",
-                                                                            "baseballstats"))
-              , info = "unexpected package dependencies derived for baseballstats"
-  )
-
-  # TODO: Need to test that nodes were properly extracted
-  testNodeDT <- testObj$nodes
-
+        , expected = fmtPath(baseball_dir)
+        , info = "set_package did not use the absolute path of the directory"
+    )
+    
+    # "extract_network"
+    expect_silent({
+        testObj$.__enclos_env__$private$extract_network()
+    })
+    
+    expect_named(
+        object = testObj$edges
+        , expected = c("SOURCE", "TARGET")
+        , info = "more than edges created by extract_network"
+        , ignore.order = FALSE # enforcing this convention
+        , ignore.case = FALSE
+    )
+    
+    expect_true(object = all(testObj$edges[,unique(c(SOURCE, TARGET))] %in% c("base",
+                                                                              "methods",
+                                                                              "utils",
+                                                                              "stats",
+                                                                              "grDevices",
+                                                                              "graphics",
+                                                                              "baseballstats"))
+                , info = "unexpected package dependencies derived for baseballstats"
+    )
+    
+    # TODO: Need to test that nodes were properly extracted
+    testNodeDT <- testObj$nodes
+    
     expect_silent({
         testObj$pkg_graph
     })
-
+    
     expect_true({
         igraph::is_igraph(testObj$pkg_graph)
     }, info = "Graph object not an igraph formatted object")
-
+    
     expect_true({
         all(igraph::get.vertex.attribute(testObj$pkg_graph)[[1]] %in% testNodeDT$node)
     }, info = "Graph nodes not as expected")
-
+    
     expect_true({
         all(igraph::get.vertex.attribute(testObj$pkg_graph)[[1]] %in% igraph::get.vertex.attribute(testObj$pkg_graph)[[1]])
     }, info = "$pkg_graph field nodes not as expected")
-
+    
     expect_identical(
         igraph::get.edgelist(testObj$pkg_graph)
         , expected = igraph::get.edgelist(testObj$pkg_graph)

--- a/tests/testthat/test-FunctionReporter.R
+++ b/tests/testthat/test-FunctionReporter.R
@@ -7,9 +7,9 @@ rm(list = ls())
 # expect_silents only work with this logger turned off; only alerts with warnings
 loggerOptions <- futile.logger::logger.options()
 if (!identical(loggerOptions, list())){
-  origLogThreshold <- loggerOptions[[1]][['threshold']]
+    origLogThreshold <- loggerOptions[[1]][['threshold']]
 } else {
-  origLogThreshold <- futile.logger::INFO
+    origLogThreshold <- futile.logger::INFO
 }
 futile.logger::flog.threshold(0)
 
@@ -18,116 +18,132 @@ futile.logger::flog.threshold(0)
 ## Structure Available ##
 
 test_that('FunctionReporter structure is as expected', {
-
-  expect_named(object = FunctionReporter$public_methods
-               , expected = c(
-                 "get_summary_view",
-                 "clone"
-               )
-               , info = "Available public methods for FunctionReporter not as expected."
-               , ignore.order = TRUE
-               , ignore.case = FALSE
-  )
-
-  expect_named(object = FunctionReporter$public_fields
-               , expected = NULL
-               , info = "Available public fields for FunctionReporter not as expected."
-               , ignore.order = TRUE
-               , ignore.case = FALSE
-  )
-
+    
+    expect_named(object = FunctionReporter$public_methods
+                 , expected = c(
+                     "get_summary_view",
+                     "clone"
+                 )
+                 , info = "Available public methods for FunctionReporter not as expected."
+                 , ignore.order = TRUE
+                 , ignore.case = FALSE
+    )
+    
+    expect_named(object = FunctionReporter$public_fields
+                 , expected = NULL
+                 , info = "Available public fields for FunctionReporter not as expected."
+                 , ignore.order = TRUE
+                 , ignore.case = FALSE
+    )
+    
 })
 
 ### USAGE OF PUBLIC AND PRIVATE METHODS AND FIELDS
 
 test_that('FunctionReporter Methods Work', {
-  testObj <- FunctionReporter$new()
-
-  # inherited set_package
-  expect_silent({
-      testObj$set_package(
-        pkg_name = "baseballstats"
-        # Covr only works on source code. find.package path will not work
-        # covr also requires an absolute path, which is provided by system.file
-        , pkg_path = system.file("baseballstats"
-                                 , package = "pkgnet"
-                                 , lib.loc = Sys.getenv('PKGNET_TEST_LIB')
-                                 )
-      )
-  })
-
-  # inherited get_package
-  expect_equal(object = testObj$pkg_name
-               , expected = "baseballstats"
-               , info = "get_package did not return expected package name")
-
-  # "extract_network"
-  testObj$.__enclos_env__$private$extract_network()
-
-  expect_named(object = testObj$edges
-               , expected = c("SOURCE", "TARGET")
-               , info = "more than SOURCE and TARGET fields created by extract_network"
-  )
-
-  expect_true({
-      all_funs <- testObj$edges[, unique(SOURCE, TARGET)]
-      all(all_funs %in% c("at_bats", "batting_avg", "slugging_avg", "OPS"))
-  }, info = "unexpected function dependencies derived for baseballstats")
-
-  # TODO: Need to test that nodes were properly extracted
-  testNodeDT <- testObj$nodes
-
-  # inherited make_graph_object
-  expect_silent(object = testPkgGraph <- testObj$pkg_graph)
-
-  expect_true(object = igraph::is_igraph(testPkgGraph)
-              , info = "Graph object not and igraph formatted object")
-
-  expect_true(object = all(igraph::get.vertex.attribute(testPkgGraph)[[1]] %in% testNodeDT$node)
-              , info = "Graph nodes not as expected")
-
-  # Nodes table with coverage and metrics too
-  # TODO: Test that calculate_all_measures and other calculates attach metadata correctly
-  # expect_identical(object = sort(testObj$get_raw_data()$nodes$node)
-  #                  , expected = sort(testNodeDT$node)
-  #                  , info = "Different nodes than expected")
-
-
-  # network measures
-  expect_true({
-      suppressWarnings({
-          all( c("centralization.OutDegree",
-                 "centralization.betweenness",
-                 "centralization.closeness"
-          ) %in% names(testObj$network_measures))
-      })
-  } , info = "Not all expected network measures are in network_measures list")
-  expect_true(object = all( c("outDegree",
-                              "outBetweeness",
-                              "outCloseness",
-                              "numDescendants",
-                              "hubScore",
-                              "pageRank",
-                              "inDegree") %in% names(testObj$nodes))
-              , info = "Not all expected network measures are in nodes data.table"
-  )
-
-  # coverage
-  expect_true(object = all( c("coverageRatio"
-                              , "meanCoveragePerLine"
-                              , "totalLines"
-                              , "coveredLines"
-                              , "filename") %in% names(testObj$nodes)
-                            )
-              , info = "Not all expected function coverage measures are in nodes table"
-  )
-
-  expect_true(object = all(igraph::get.vertex.attribute(testObj$pkg_graph)[[1]] %in% igraph::get.vertex.attribute(testPkgGraph)[[1]])
-              , info = "pkgGraph field nodes not as expected")
-
-  expect_identical(object = igraph::get.edgelist(testObj$pkg_graph)
-                   , expected = igraph::get.edgelist(testPkgGraph)
-                   , info = "pkgGraph field edges not as expected")
+    testObj <- FunctionReporter$new()
+    
+    # inherited set_package
+    expect_silent({
+        testObj$set_package(
+            pkg_name = "baseballstats"
+            # Covr only works on source code. find.package path will not work
+            # covr also requires an absolute path, which is provided by system.file
+            , pkg_path = system.file("baseballstats"
+                                     , package = "pkgnet"
+                                     , lib.loc = Sys.getenv('PKGNET_TEST_LIB')
+            )
+        )
+    })
+    
+    # inherited get_package
+    expect_equal(object = testObj$pkg_name
+                 , expected = "baseballstats"
+                 , info = "get_package did not return expected package name")
+    
+    # "extract_network"
+    testObj$.__enclos_env__$private$extract_network()
+    
+    expect_named(object = testObj$edges
+                 , expected = c("SOURCE", "TARGET")
+                 , info = "more than SOURCE and TARGET fields created by extract_network"
+    )
+    
+    expect_true({
+        all_funs <- testObj$edges[, unique(SOURCE, TARGET)]
+        all(all_funs %in% c("at_bats", "batting_avg", "slugging_avg", "OPS"))
+    }, info = "unexpected function dependencies derived for baseballstats")
+    
+    # Test that all expected edges were derived and in the correct directions
+    # Convention: If B depends on A, then B is the TARGET 
+    # and A is the SOURCE so that it looks like A -> B
+    baseballstatsExpectedEdges <- data.table::rbindlist(list(
+        list(TARGET = 'batting_avg', SOURCE = 'at_bats')
+        , list(TARGET = 'slugging_avg', SOURCE = 'at_bats')
+        , list(TARGET = 'OPS', SOURCE = 'batting_avg')
+        , list(TARGET = 'OPS', SOURCE = 'slugging_avg')
+    ))
+    expect_equal(object = testObj$edges
+                 , expected = baseballstatsExpectedEdges
+                 , ignore.col.order = TRUE
+                 , ignore.row.order = TRUE
+                 , info = "derived edges do not match expected edges"
+                 )
+    
+    # TODO: Need to test that nodes were properly extracted
+    testNodeDT <- testObj$nodes
+    
+    # inherited make_graph_object
+    expect_silent(object = testPkgGraph <- testObj$pkg_graph)
+    
+    expect_true(object = igraph::is_igraph(testPkgGraph)
+                , info = "Graph object not and igraph formatted object")
+    
+    expect_true(object = all(igraph::get.vertex.attribute(testPkgGraph)[[1]] %in% testNodeDT$node)
+                , info = "Graph nodes not as expected")
+    
+    # Nodes table with coverage and metrics too
+    # TODO: Test that calculate_all_measures and other calculates attach metadata correctly
+    # expect_identical(object = sort(testObj$get_raw_data()$nodes$node)
+    #                  , expected = sort(testNodeDT$node)
+    #                  , info = "Different nodes than expected")
+    
+    
+    # network measures
+    expect_true({
+        suppressWarnings({
+            all( c("centralization.OutDegree",
+                   "centralization.betweenness",
+                   "centralization.closeness"
+            ) %in% names(testObj$network_measures))
+        })
+    } , info = "Not all expected network measures are in network_measures list")
+    expect_true(object = all( c("outDegree",
+                                "outBetweeness",
+                                "outCloseness",
+                                "numDescendants",
+                                "hubScore",
+                                "pageRank",
+                                "inDegree") %in% names(testObj$nodes))
+                , info = "Not all expected network measures are in nodes data.table"
+    )
+    
+    # coverage
+    expect_true(object = all( c("coverageRatio"
+                                , "meanCoveragePerLine"
+                                , "totalLines"
+                                , "coveredLines"
+                                , "filename") %in% names(testObj$nodes)
+    )
+    , info = "Not all expected function coverage measures are in nodes table"
+    )
+    
+    expect_true(object = all(igraph::get.vertex.attribute(testObj$pkg_graph)[[1]] %in% igraph::get.vertex.attribute(testPkgGraph)[[1]])
+                , info = "pkgGraph field nodes not as expected")
+    
+    expect_identical(object = igraph::get.edgelist(testObj$pkg_graph)
+                     , expected = igraph::get.edgelist(testPkgGraph)
+                     , info = "pkgGraph field edges not as expected")
 })
 
 
@@ -139,7 +155,6 @@ test_that("FunctionReporter rejects bad packages with an informative error", {
         )
     }, regexp = "pkgnet could not find a package called 'w0uldNEverB33aPackageName'")
 })
-
 
 ##### TEST TEAR DOWN #####
 


### PR DESCRIPTION
- Refactored `FunctionReporter` so that node and edge extraction generate a node list in one place (in the `extract_nodes` method)
- Updated `FunctionReporter` to also include non-exported functions. Addresses #122. Sorry I forgot to put it in the commit message.
- Fixed `FunctionReporter` to properly return an empty edge data.table in the case with no edges. This can happen if you only have orphan functions. Previously it would do this only in the case where a package had one function, but in that case if there was one recursive function it would incorrectly return an empty edge table. 
- Added some RStudio project files to .gitignore and .Rbuildignore
- UPDATE: Fixed reversed edge direction and added unit test. Addresses #127 

