### PR TITLE
Fixed bug with FunctionReporter and environment pointers

### DIFF
--- a/R/PackageFunctionReporter.R
+++ b/R/PackageFunctionReporter.R
@@ -266,7 +266,7 @@ FunctionReporter <- R6::R6Class(
 #               vector separating the individual symbols
 .parse_function <- function (x) {
 
-    listable <- (!is.atomic(x) && !is.symbol(x))
+    listable <- (!is.atomic(x) && !is.symbol(x) && !is.environment(x))
 
     if (!is.list(x) && listable) {
         x <- as.list(x)


### PR DESCRIPTION
Fixes a bug where the function .parse_function used by `FunctionReporter` chokes on environment pointers.

This was discovered by finding out the following error when trying to calculate edges for the `lubridate` package:
```
 Error in as.vector(x, "list") : 
  cannot coerce type 'externalptr' to vector of type 'list' 
```

This is because lubridate has [this bit](https://github.com/tidyverse/lubridate/blob/ea25ca629ccd7598f2e2271146c8f551acb26096/R/POSIXt.r#L54-L57) which uses `evalqOnLoad` to register the S3 method `c.POSIXct`.

This creates some hidden functions in the lubridate namespace, one of which is the function `.__A__.1`:
```
function (env) 
eval({
    registerS3method("c", "POSIXct", c.POSIXct)
}, <environment>)
```
where `<environment>` is a pointer to `<environment: namespace:lubridate>`.

Basically to address it, we are considering environment pointers as unlistable. 