### PR TITLE
Restored missing depdency table (fixes #136)

### DIFF
--- a/inst/package_report/package_dependency_reporter.Rmd
+++ b/inst/package_report/package_dependency_reporter.Rmd
@@ -22,4 +22,5 @@ result <- tryCatch({
 }, error = function(e){
     return(sprintf("DependencyReporter failed with error %s", e$message))
 })
+result
 ```

--- a/tests/testthat/test-CreatePackageReport.R
+++ b/tests/testthat/test-CreatePackageReport.R
@@ -29,6 +29,28 @@ test_that("Test that CreatePackageReport Runs", {
     file.remove(testReportPath)
 })
 
+test_that("CreatePackageReports generates the expected tables", {
+
+    testReportPath <- tempfile(
+        pattern = "baseball"
+        , fileext = ".html"
+    )
+
+    reporters <- CreatePackageReport(
+        pkg_name = "baseballstats"
+        , report_path = testReportPath
+    )
+
+    report_html <- readLines(testReportPath)
+
+    num_tables <-  sum(grepl('datatables html-widget', report_html))
+
+    # One table per reporter
+    expect_true(num_tables == length(DefaultReporters()))
+
+    file.remove(testReportPath)
+})
+
 test_that("CreatePackageReport rejects bad inputs to reporters", {
 
     expect_error({


### PR DESCRIPTION
This PR restores the table view on the dependency network page.

I verified this by running `CreatePackageReport('ggplot2')` and visually inspecting the output. I also added a unit test to prevent a regression in the future.