### PR TITLE
made testing strategy portable (fixes #121)

### DIFF
--- a/R/testing_utils.R
+++ b/R/testing_utils.R
@@ -40,11 +40,14 @@
     #       work the same way and causes that error. Just trust me on this.
     #
     # NOTE: "Sys.which()" would be the correct, portable way to do this but it
-    # doesn't support matching ALL matches, so for now we'll make it work
-    # on unix-alike operating systems and deal with Windows later
+    # doesn't support matching ALL matches.
     #
-    R_LOC <- system("which -a R", intern = TRUE)
-    R_LOC <- R_LOC[!grepl("R_check_bin", R_LOC)][1]
+    if (.Platform$OS.type == 'windows'){
+        R_LOCS <- system("where R", intern = TRUE)
+    } else {
+        R_LOCS <- system("which -a R", intern = TRUE)
+    }
+    R_LOC <- R_LOCS[!grepl("R_check_bin", R_LOCS)][1]
 
     # force install of SOURCE (not binary) in temporary directory for tests
     cmdstr <- sprintf(


### PR DESCRIPTION
I tried this on a Windows laptop tonight and confirmed it works. I believe `where` is a core part of Windows and should be as ubiquitous in that world as `which` is in Unix-alike distributions.

Fixes #121, removing the last technical barrier to our next release. Now it's just up to us to address the other functional things called out in [the milestone](https://github.com/UptakeOpenSource/pkgnet/milestone/1).