### PR TITLE
Colorblind Safe Palette For Function Coverage

### DIFF
--- a/R/PackageFunctionReporter.R
+++ b/R/PackageFunctionReporter.R
@@ -155,7 +155,11 @@ FunctionReporter <- R6::R6Class(
             # Set Graph to Color By Coverage
             private$set_plot_node_color_scheme(
                 field = "coverageRatio"
-                , palette = c("red", "green")
+                # colorbrewer2.org PiYG Palatte
+                , palette = c("#e9a3c9"         # Shocking - low values
+                              , "#f7f7f7"       # White Smoke - mid range values
+                              , "#a1d76a"       # Feijoa - high values
+                              )
             )
 
             # Calculate network measures since we need outBetweeness

--- a/R/PackageFunctionReporter.R
+++ b/R/PackageFunctionReporter.R
@@ -155,7 +155,7 @@ FunctionReporter <- R6::R6Class(
             # Set Graph to Color By Coverage
             private$set_plot_node_color_scheme(
                 field = "coverageRatio"
-                # colorbrewer2.org PiYG Palatte
+                # colorbrewer2.org PiYG - Colorblind Safe Palatte
                 , palette = c("#e9a3c9"         # Shocking - low values
                               , "#f7f7f7"       # White Smoke - mid range values
                               , "#a1d76a"       # Feijoa - high values


### PR DESCRIPTION
Addressing #130, the default palette for function reporter is changed to the [PiYG palette from ColorBrewer](http://colorbrewer2.org/#type=diverging&scheme=PiYG&n=3).  

Here are examples of the palette implemented with this PR:  

![image](https://user-images.githubusercontent.com/24531403/49348107-20609680-f669-11e8-90a7-8718804126f0.png)


![image](https://user-images.githubusercontent.com/24531403/49348112-25bde100-f669-11e8-9f91-27853d585a1b.png)
