### PR TITLE
Fixed .BuildTestLib for covr

### DIFF
--- a/R/testing_utils.R
+++ b/R/testing_utils.R
@@ -12,6 +12,7 @@
     #       from the repo root if something goes wrong
 
     # [DEBUG] write("=========", file = "~/thing.txt", append = TRUE)
+    # [DEBUG] write(paste0("target lib path: ", targetLibPath), file = "~/thing.txt", append = TRUE)
     # [DEBUG] write(list.files(getwd(), recursive = TRUE), file = "~/thing.txt", append = TRUE)
     # [DEBUG] write(paste0("working dir: ", getwd()), file = "~/thing.txt", append = TRUE)
 
@@ -20,17 +21,31 @@
     pkgnetSourcePath <- gsub('/pkgnet.Rcheck/vign_test/pkgnet$', replacement = '/pkgnet.Rcheck/00_pkg_src/pkgnet', x = pkgnetSourcePath)
     pkgnetSourcePath <- gsub('/pkgnet/vignettes$', replacement = '/pkgnet', x = pkgnetSourcePath)
     pkgnetSourcePath <- gsub('pkgnet/tests/testthat', replacement = 'pkgnet', x = pkgnetSourcePath)
+    pkgnetSourcePath <- gsub('/pkgnet/pkgnet-tests/testthat', replacement = '/pkgnet', x = pkgnetSourcePath) # covr
+    pkgnetSourcePath <- gsub('/pkgnet/pkgnet-tests', replacement = '/pkgnet', x = pkgnetSourcePath) # covr
 
     # [DEBUG] write(paste0("pkgnet path: ", pkgnetSourcePath), file = "~/thing.txt", append = TRUE)
-    # [DEBUG] write("=========", file = "~/thing.txt", append = TRUE)
+    # [DEBUG] write(list.files(pkgnetSourcePath, recursive = TRUE), file = "~/thing.txt", append = TRUE)
+
+    # Check if there is an inst directory in pkgnetSource.
+    # If there is an inst directory (because of raw package copy) then look in there
+    # for the test packages.
+    # Otherwise if not, it means that it's an installed package copy and the test
+    # packages are in the package root directory.
+    testPkgSourceDir <- ""
+    if ("inst" %in% list.files(pkgnetSourcePath)) {
+        testPkgSourceDir <- "inst"
+    }
 
     ### packages to be built
     pkgList <- c(
-        baseballstats = file.path(pkgnetSourcePath, "inst", "baseballstats")
-        , sartre = file.path(pkgnetSourcePath, "inst", "sartre")
-        , milne = file.path(pkgnetSourcePath, "inst", "milne")
+        baseballstats = file.path(pkgnetSourcePath, testPkgSourceDir, "baseballstats")
+        , sartre = file.path(pkgnetSourcePath, testPkgSourceDir, "sartre")
+        , milne = file.path(pkgnetSourcePath, testPkgSourceDir, "milne")
         , pkgnet = pkgnetSourcePath
     )
+
+    # [DEBUG] write(paste0("Installing: ", paste(pkgList)), file = "~/thing.txt", append = TRUE)
 
     ### Install
 
@@ -70,6 +85,8 @@
             , paste0(output, collapse = " ... ")
         ))
     }
+
+    # [DEBUG] write("=========", file = "~/thing.txt", append = TRUE)
 
     return(invisible(TRUE))
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -19,6 +19,8 @@ if (Sys.getenv('PKGNET_REBUILD')){
     ## travis checks.
     ## ******************************************************************************************
 
+    # [DEBUG] write("PKGNET_REBUILD triggered", file = "~/thing.txt", append = TRUE)
+
     # record original libpaths in order to reset later.
     # This should be unnecessary since tests are conducted within a seperate enviornment.
     # It's done out of an abundance of caution.
@@ -39,6 +41,10 @@ if (Sys.getenv('PKGNET_REBUILD')){
         targetLibPath = Sys.getenv('PKGNET_TEST_LIB')
     )
 
+    # [DEBUG] write(paste0("PKGNET_TEST_LIB: ", Sys.getenv('PKGNET_TEST_LIB')), file = "~/thing.txt", append = TRUE)
+    # [DEBUG] write(list.files(Sys.getenv('PKGNET_TEST_LIB'), recursive = TRUE), file = "~/thing.txt", append = TRUE)
+
+
 }
 
 # This withr statement should be redundant.
@@ -56,6 +62,8 @@ if (Sys.getenv('PKGNET_REBUILD')){
     ## THIS IS THIS SAME CONTENT as teardown_setTestEnv.R but neccessary to paste here due to
     ## travis checks.
     ## ******************************************************************************************
+
+    # [DEBUG] write("PKGNET_REBUILD tear-down triggered", file = "~/thing.txt", append = TRUE)
 
     # Uninstall Fake Packages From Test Library if Not Already Uninstalled
     try(

--- a/tests/testthat/setup_setTestEnv.R
+++ b/tests/testthat/setup_setTestEnv.R
@@ -1,3 +1,5 @@
+# Check if the setup in testthat.R was already run
+# [DEBUG] write("setup_setTestEnv.R triggered", file = "~/thing.txt", append = TRUE)
 
 # record original libpaths in order to reset later.
 # This should be unnecessary since tests are conducted within a seperate enviornment.
@@ -18,3 +20,7 @@ Sys.setenv(PKGNET_TEST_LIB = tempdir())
 pkgnet:::.BuildTestLib(
     targetLibPath = Sys.getenv('PKGNET_TEST_LIB')
 )
+
+# [DEBUG] write(paste0("PKGNET_TEST_LIB: ", Sys.getenv('PKGNET_TEST_LIB')), file = "~/thing.txt", append = TRUE)
+# [DEBUG] write(list.files(Sys.getenv('PKGNET_TEST_LIB'), recursive = TRUE), file = "~/thing.txt", append = TRUE)
+

--- a/tests/testthat/teardown_setTestEnv.R
+++ b/tests/testthat/teardown_setTestEnv.R
@@ -1,10 +1,10 @@
-
+# [DEBUG] write("teardown_setTestEnv.R triggered", file = "~/thing.txt", append = TRUE)
 
 # Uninstall Fake Packages From Test Library if Not Already Uninstalled
 try(
     utils::remove.packages(
         pkgs = c('baseballstats', 'sartre', 'milne', 'pkgnet')
-       , lib = Sys.getenv('PKGNET_TEST_LIB')
+        , lib = Sys.getenv('PKGNET_TEST_LIB')
     )
 )
 


### PR DESCRIPTION
`covr` has been broken with pkgnet for a while, since #108 was merged.

This has caused our codecov to [silently fail](https://travis-ci.org/UptakeOpenSource/pkgnet/builds/451194948) in in the Travis "after_success" build steps. 

The same error was seen when trying to run `covr::package_coverage` locally (or by trying to run `FunctionReporter` with `calculate_test_coverage`). 

This was due to the way `covr` installs the package into a temporary directory before it does all of its stuff. The directory structure in the `covr` case wasn't included in the list of directory sanitation in `.BuildTestLib`.

Additionally, because we had to install the test packages from an installed copy of `pkgnet` source rather than the raw source, the test packages had all been moved out of inst up into the root package directory, so the path to the test package source had to be adjusted.