### PR TITLE
FunctionReporter handling of list extraction symbols

### DIFF
--- a/R/CreatePackageReport.R
+++ b/R/CreatePackageReport.R
@@ -59,7 +59,10 @@ CreatePackageReport <- function(pkg_name
       , pkg_name = pkg_name
     )
 
-    utils::browseURL(report_path)
+    # If suppress flag is unset, then env variable will be emptry string ""
+    if (identical(Sys.getenv("PKGNET_SUPPRESS_BROWSER"), "")) {
+        utils::browseURL(report_path)
+    }
 
     return(invisible(builtReporters))
 }

--- a/man/FunctionReporter.Rd
+++ b/man/FunctionReporter.Rd
@@ -41,6 +41,23 @@ or to be the same as the generator object name.
 }
 }
 
+\section{Known Limitations}{
+
+\itemize{
+    \item{Using non-standard evaluation to refer to things (e.g, dataframe column names)
+    that have the same name as a function will trick \code{FunctionReporter} into thinking
+    the function was called. This can be avoided if you don't use reuse function names
+    for other purposes.}
+    \item{Functions stored as list items and not assigned to the package namespace
+    will be invisible to \code{FunctionReporter}.}
+    \item{Calls to methods of instantiated R6 or reference objects will not be recognized.
+    We don't have a reliable way of identifying instantiated objects, or identifying
+    their class.}
+    \item{Reference class methods are not yet supported. They will not be idenified
+    as nodes by \code{FunctionReporter}.}
+}
+}
+
 \seealso{
 Other PackageReporters: \code{\link{DependencyReporter}},
   \code{\link{InheritanceReporter}},

--- a/tests/testthat/test-CreatePackageReport.R
+++ b/tests/testthat/test-CreatePackageReport.R
@@ -9,6 +9,9 @@ if (!identical(loggerOptions, list())){
 }
 futile.logger::flog.threshold(0,name=futile.logger::flog.namespace())
 
+# Set flag to suppress browser opening
+Sys.setenv(PKGNET_SUPPRESS_BROWSER = TRUE)
+
 test_that("Test that CreatePackageReport Runs", {
 
     testReportPath <- tempfile(
@@ -124,6 +127,8 @@ test_that("CreatePackageReport respects report_path when explicitly given", {
 })
 
 ##### TEST TEAR DOWN #####
+
+Sys.unsetenv("PKGNET_SUPPRESS_BROWSER")
 
 futile.logger::flog.threshold(origLogThreshold)
 rm(list = ls())


### PR DESCRIPTION
- Resolves #126.
    - `.parse_function` and `.parse_R6_expression` will ignore the righthand side `bar` of expressions like `foo$bar`. This means if someone names a list item the same as a function in the package namespace, `FunctionReporter` won't think references to it are calls to the same-named function.
    - Added a "Known Limitations" section to roxygen documention for `FunctionReporter` addressing non-standard evaluation, among others.
- Added unit tests for `.parse_function` and `.parse_R6_expression`
- Added a `PKGNET_SUPPRESS_BROWSER` env variable so that running the tests won't keep opening baesballstats package reports in the browser. 