### PR TITLE
test on mac and linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: R
 cache: packages
 warnings_are_errors: true
 
+os:
+  - linux
+  - osx
+
 before_install:
 - Rscript -e "install.packages('roxygen2', repos = 'http://cran.rstudio.org')"
 - Rscript -e "install.packages('devtools', repos = 'http://cran.rstudio.org')"


### PR DESCRIPTION
I've been reading the [travis docs](https://docs.travis-ci.com/user/multi-os/) and I saw that you can test on Mac OSX on Travis! In this PR, I propose we test on both Linux (which I believe is Ubuntu in the travis testing farm) and OSX.