### PR TITLE
Fixed weird, inconsistent data.table error in group by

### DIFF
--- a/R/AbstractGraphReporter.R
+++ b/R/AbstractGraphReporter.R
@@ -351,7 +351,7 @@ AbstractGraphReporter <- R6::R6Class(
                     newPalette <- grDevices::colorRampPalette(colors = colorFieldPalette)(valCount)
 
                     # For each character value, update all nodes with that value
-                    plotDTnodes[, color := newPalette[.GRP], by = get(colorFieldName)]
+                    plotDTnodes[, color := newPalette[.GRP], by = .(get(colorFieldName))]
 
                     # Set the group column to the field
                     plotDTnodes[, group := get(colorFieldName)]


### PR DESCRIPTION
Fixes a fickle bug where sometimes data.table complains when it executes this line:

https://github.com/UptakeOpenSource/pkgnet/blob/9a898614eeb52176228afcb9ec9d7d43ad6971c3/R/AbstractGraphReporter.R#L354

> Error in `[.data.table`(plotDTnodes, , `:=`(color, newPalette[.GRP]),  : 
  'by' appears to evaluate to column names but isn't c() or key(). Use by=list(...) if you can. Otherwise, by=eval(get(colorFieldName)) should work. This is for efficiency so data.table can detect which columns are needed.
