### PR TITLE
infrastructure necessary for devtools::test AND CRAN

### DIFF
--- a/tests/testthat/setup_setTestEnv.R
+++ b/tests/testthat/setup_setTestEnv.R
@@ -1,0 +1,28 @@
+
+print(Sys.getenv("NOT_CRAN"))
+if(identical(Sys.getenv("NOT_CRAN"), "true")){
+    ######## TRAVIS and LOCAL TEST PROCEDURE #############
+    
+    # record original libpaths in order to reset later.
+    # This should be unnecessary since tests are conducted within a seperate enviornment.
+    # It's done out of an abundance of caution.
+    origLibPaths <- .libPaths()
+    
+    # Set the pkgnet library for testing to a temp directory
+    Sys.setenv(PKGNET_TEST_LIB = tempdir())
+    
+    # Set the libpaths for testing.
+    # This has no effect to global libpaths since testing tests are conducted within a seperate enviornment.
+    .libPaths(new = c(
+        Sys.getenv('PKGNET_TEST_LIB')
+        , origLibPaths
+    ))
+    
+    # Install Fake Packages - For local testing if not already installed
+    pkgnet:::.BuildTestLib(
+        targetLibPath = Sys.getenv('PKGNET_TEST_LIB')
+    )
+    
+}
+
+

--- a/tests/testthat/teardown_setTestEnv.R
+++ b/tests/testthat/teardown_setTestEnv.R
@@ -1,0 +1,21 @@
+
+print(Sys.getenv("NOT_CRAN"))
+if(identical(Sys.getenv("NOT_CRAN"), "true")){
+    # Uninstall Fake Packages From Test Library if Not Already Uninstalled
+    try(
+        utils::remove.packages(
+            pkgs = c('baseballstats', 'sartre', 'milne', 'pkgnet')
+            , lib = Sys.getenv('PKGNET_TEST_LIB')
+        )
+    )
+    
+    # Reset libpaths.
+    # This should be unnecessary since tests are conducted within a seperate enviornment.
+    # It's done out of an abundance of caution.
+    .libPaths(origLibPaths)
+    
+    # Remove test libary path eviornment variable.
+    Sys.unsetenv('PKGNET_TEST_LIB')
+}
+
+


### PR DESCRIPTION
With v0.3.1, we deleted the setup and teardown files necessary for `devtools::test()` in favor of clearing issues those files caused for the CRAN testing process.  However, with the same if statements added elsewhere in the unit tests (same code as `devtools::skip_on_cran`) wrapping these files, we should be able to satisfy both. 

When [testing on r-devel](https://alexandereckert.com/post/testing-r-packages-with-latest-r-devel/), I do not see test packages loading.  This is a good sign. Here's the log: 
```
root@c0389a2cbe4d:/RPackage# RD CMD check --as-cran  --no-vignettes pkgnet_0.3.1.9999.tar.gz 
root@c0389a2cbe4d:/RPackage# cat /RPackage/pkgnet.Rcheck/tests/testthat.Rout

R Under development (unstable) (2018-12-21 r75875) -- "Unsuffered Consequences"
Copyright (C) 2018 The R Foundation for Statistical Computing
Platform: x86_64-pc-linux-gnu (64-bit)

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under certain conditions.
Type 'license()' or 'licence()' for distribution details.

R is a collaborative project with many contributors.
Type 'contributors()' for more information and
'citation()' on how to cite R or R packages in publications.

Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

> # Note that you would never run this file directly. This is used by tools::testInstallPackages()
> # and other packages like covr.
> # To actually run the tests, you need to set the working directory then run
> # devtools::test('pkgnet')
> 
> # This line ensures that R CMD check can run tests.
> # See https://github.com/hadley/testthat/issues/144
> Sys.setenv("R_TESTS" = "")
> 
> 
> #######  TESTING ON vs. OFF CRAN #############
> # Due to complications on CRAN with handling of temporary packages during testing, TRAVIS 
> # and local testing will remain the main test processes for pkgnet. 
> # See https://github.com/UptakeOpenSource/pkgnet/issues/160 for details on this decision.
> 
> print(Sys.getenv("NOT_CRAN"))
[1] ""
> if(identical(Sys.getenv("NOT_CRAN"), "true")){
+     ######## TRAVIS and LOCAL TEST PROCEDURE #############
+     
+     # Check if setup and helper funs have been run.
+     # If in R CMD CHECK, they may not have been run yet.
+     Sys.setenv(PKGNET_REBUILD = identical(Sys.getenv('PKGNET_TEST_LIB'), ''))
+     
+     # If not yet run, rebuild
+     if (Sys.getenv('PKGNET_REBUILD')){
+         library(pkgnet)
+         ## ******************************************************************************************
+         ## THIS IS THIS SAME CONTENT as setup_setTestEnv.R but neccessary to paste here due to
+         ## travis checks.
+         ## ******************************************************************************************
+         
+         # [DEBUG] write("PKGNET_REBUILD triggered", file = "~/thing.txt", append = TRUE)
+         
+         # record original libpaths in order to reset later.
+         # This should be unnecessary since tests are conducted within a seperate enviornment.
+         # It's done out of an abundance of caution.
+         origLibPaths <- .libPaths()
+         
+         # Set the pkgnet library for testing to a temp directory
+         Sys.setenv(PKGNET_TEST_LIB = tempdir())
+         
+         # Set the libpaths for testing.
+         # This has no effect to global libpaths since testing tests are conducted within a
+         # seperate enviornment.
+         .libPaths(
+             new = c(Sys.getenv('PKGNET_TEST_LIB'), origLibPaths)
+         )
+         
+         # Install Fake Packages - For local testing if not already installed
+         pkgnet:::.BuildTestLib(
+             targetLibPath = Sys.getenv('PKGNET_TEST_LIB')
+         )
+         
+         # [DEBUG] write(paste0("PKGNET_TEST_LIB: ", Sys.getenv('PKGNET_TEST_LIB')), file = "~/thing.txt", append = TRUE)
+         # [DEBUG] write(list.files(Sys.getenv('PKGNET_TEST_LIB'), recursive = TRUE), file = "~/thing.txt", append = TRUE)
+         
+         
+     }
+     
+     # This withr statement should be redundant.
+     # This is within a test environment in which .libpaths() has been altered to include PKGNET_TEST_LIB.
+     # Yet, it appears to be necessary.
+     withr::with_libpaths(
+         new =  .libPaths()
+         , code = {testthat::test_check('pkgnet')}
+     )
+     
+     # Tear down temporary test enviorment
+     if (Sys.getenv('PKGNET_REBUILD')){
+         
+         ## ******************************************************************************************
+         ## THIS IS THIS SAME CONTENT as teardown_setTestEnv.R but neccessary to paste here due to
+         ## travis checks.
+         ## ******************************************************************************************
+         
+         # [DEBUG] write("PKGNET_REBUILD tear-down triggered", file = "~/thing.txt", append = TRUE)
+         
+         # Uninstall Fake Packages From Test Library if Not Already Uninstalled
+         try(
+             utils::remove.packages(
+                 pkgs = c('baseballstats', 'sartre', 'milne', 'pkgnet')
+                 , lib = Sys.getenv('PKGNET_TEST_LIB')
+             )
+         )
+         
+         # Reset libpaths.
+         # This should be unnecessary since tests are conducted within a seperate enviornment.
+         # It's done out of an abundance of caution.
+         .libPaths(origLibPaths)
+         
+         # Remove test libary path eviornment variable.
+         Sys.unsetenv('PKGNET_TEST_LIB')
+     } 
+ } else {
+     ######## ON CRAN TEST PROCEDURE #############
+     testthat::test_check(package = "pkgnet"
+                          , filter = "cran-true"
+                          , load_helpers = FALSE
+     )
+     
+ }
Loading required package: pkgnet

Attaching package: 'pkgnet'

The following object is masked from 'package:testthat':

    SummaryReporter

[1] ""
══ testthat results  ═══════════════════════════════════════════════════════════
OK: 1 SKIPPED: 0 FAILED: 0
[1] ""
> 
> 
> 
> proc.time()
   user  system elapsed 
  0.580   0.050   0.647 
```

Notice only 1 unit test and no loading of test packages, as expected.  Also notice the two empty strings printed by the setup and teardown files respectively. 

At the same time, `devtools::test()` runs locally: 
```
> devtools::test(".")
Loading pkgnet
Testing pkgnet
[1] "true"
✔ | OK F W S | Context
✔ |  3       | Abstract Graph Reporter Tests
✔ |  3       | Abstract Package Reporter Tests
✔ |  1       | always true for cran
✔ | 13       | CreatePackageReport [3.2 s]
✔ | 14       | Package Dependency Reporter Tests
✔ | 15       | Creation of graph of package functions [0.3 s]
✔ | 20       | Package Function Reporter Tests [1.5 s]
✔ | 15       | Package Class Inheritance Reporter Tests [0.1 s]
✔ |  3       | logging
✔ |  3       | Plotting Tests [1.5 s]

══ Results ═══════════════════════════════════════════════════════════════════════════════════════════════════
Duration: 6.8 s

OK:       90
Failed:   0
Warnings: 0
Skipped:  0
[1] "true"
```

Notice the two "true"'s created by the setup and teardown files respectively.  





    