### PR TITLE
removed TODOs from code

### DIFF
--- a/R/AbstractGraphReporter.R
+++ b/R/AbstractGraphReporter.R
@@ -115,14 +115,14 @@ AbstractGraphReporter <- R6::R6Class(
                 graph = pkg_graph
                 , mode = "out"
             )
-            
+
             outDegreeResultDT <- data.table::data.table(node = igraph::vertex.attributes(pkg_graph)[['name']]
                                                         , outDegree = outDegreeResult[['res']]
                                                         )
 
             # update data.tables
             private$update_nodes(outDegreeResultDT)
-            
+
             private$cache$network_measures[['centralization.OutDegree']] <- outDegreeResult$centralization
 
             #--------------#
@@ -132,11 +132,11 @@ AbstractGraphReporter <- R6::R6Class(
                 graph = pkg_graph
                 , directed = TRUE
             )
-            
+
             outBetweenessResultDT <- data.table::data.table(node = igraph::vertex.attributes(pkg_graph)[['name']]
                                                         , outBetweeness = outBetweenessResult[['res']]
             )
-            
+
             # update data.tables
             private$update_nodes(outBetweenessResultDT)
 
@@ -155,10 +155,10 @@ AbstractGraphReporter <- R6::R6Class(
             outClosenessResultDT <- data.table::data.table(node = igraph::vertex.attributes(pkg_graph)[['name']]
                                                             , outCloseness = outClosenessResult[['res']]
             )
-            
+
             # update data.tables
             private$update_nodes(metadataDT = outClosenessResultDT)
-            
+
             private$cache$network_measures[['centralization.closeness']] <- outClosenessResult$centralization
 
             #--------------------------------------------------------------#
@@ -174,11 +174,11 @@ AbstractGraphReporter <- R6::R6Class(
                 , order = vcount(pkg_graph)
                 , mode = "out"
             )
-            
+
             numOutNodesDT <- data.table::data.table(node = igraph::vertex.attributes(pkg_graph)[['name']]
                                                            , outSubgraphSize = numOutNodes
             )
-            
+
             # update data.tables
             private$update_nodes(numOutNodesDT)
 
@@ -192,11 +192,11 @@ AbstractGraphReporter <- R6::R6Class(
                 , order = vcount(pkg_graph)
                 , mode = "in"
             )
-            
+
             numInNodesDT <- data.table::data.table(node = igraph::vertex.attributes(pkg_graph)[['name']]
                                                     , inSubgraphSize = numInNodes
             )
-            
+
             # update data.tables
             private$update_nodes(numInNodesDT)
 
@@ -207,11 +207,11 @@ AbstractGraphReporter <- R6::R6Class(
                 graph = pkg_graph
                 , scale = TRUE
             )
-            
+
             hubScoreResultDT <- data.table::data.table(node = igraph::vertex.attributes(pkg_graph)[['name']]
                                                    , hubScore = hubScoreResult$vector
             )
-            
+
             # update data.tables
             private$update_nodes(hubScoreResultDT)
 
@@ -219,11 +219,11 @@ AbstractGraphReporter <- R6::R6Class(
             # PageRank
             #--------------#
             pageRankResult <- igraph::page_rank(graph = pkg_graph, directed = TRUE)
-            
+
             pageRankResultDT <- data.table::data.table(node = igraph::vertex.attributes(pkg_graph)[['name']]
                                                        , pageRank = pageRankResult$vector
             )
-            
+
             # update data.tables
             private$update_nodes(pageRankResultDT)
 
@@ -231,11 +231,11 @@ AbstractGraphReporter <- R6::R6Class(
             # in degree
             #--------------#
             inDegreeResult <- igraph::degree(pkg_graph, mode = "in")
-            
+
             inDegreeResultDT <- data.table::data.table(node = igraph::vertex.attributes(pkg_graph)[['name']]
                                                        , inDegree = inDegreeResult
             )
-            
+
             # update data.tables
             private$update_nodes(inDegreeResultDT)
 
@@ -246,7 +246,7 @@ AbstractGraphReporter <- R6::R6Class(
 
             #motifs?
             #knn/assortivity?
-            
+
 
             return(invisible(NULL))
         },
@@ -441,7 +441,7 @@ AbstractGraphReporter <- R6::R6Class(
                 plotDTedges <- data.table::copy(self$edges) # Don't modify original
                 plotDTedges[, from := SOURCE]
                 plotDTedges[, to := TARGET]
-                plotDTedges[, color := '#848484'] # TODO Make edge formatting flexible too
+                plotDTedges[, color := '#848484']
             } else {
                 plotDTedges <- NULL
             }
@@ -482,10 +482,6 @@ AbstractGraphReporter <- R6::R6Class(
                 }
 
                 # Add legend
-                # but it is broken if there is only one level
-                # so hard-code for now to skip if there is only one level
-                # TODO: remove if statement when the following issue is resolved:
-                # https://github.com/datastorm-open/visNetwork/issues/290
                 if (length(colorFieldValues) > 1) {
                     g <- visNetwork::visLegend(
                         graph = g

--- a/R/PackageDependencyReporter.R
+++ b/R/PackageDependencyReporter.R
@@ -26,9 +26,6 @@ DependencyReporter <- R6::R6Class(
     "DependencyReporter",
     inherit = AbstractGraphReporter,
 
-    #TODO [patrick.boueri@uptake.com]: Add more robust error checks and logging
-    #TODO [patrick.boueri@uptake.com]: Add version information to dependency structure
-
     public = list(
 
         initialize = function(dep_types = c("Imports", "Depends"), installed = TRUE){

--- a/R/PackageFunctionReporter.R
+++ b/R/PackageFunctionReporter.R
@@ -210,8 +210,6 @@ FunctionReporter <- R6::R6Class(
             private$cache$edges <- private$extract_edges()
             log_info('Done extracting edges.')
 
-            # TODO (james.lamb@uptake.com):
-            # Make this handoff with coverage cleaner
             if (!is.null(private$pkg_path)){
                 private$calculate_test_coverage()
             }

--- a/tests/testthat/test-DependencyReporter.R
+++ b/tests/testthat/test-DependencyReporter.R
@@ -17,7 +17,7 @@ futile.logger::flog.threshold(0)
 ## Structure Available ##
 
 test_that('DependencyReporter structure is as expected', {
-    
+
     expect_named(object = DependencyReporter$public_methods
                  , expected = c(
                      "get_summary_view",
@@ -28,24 +28,24 @@ test_that('DependencyReporter structure is as expected', {
                  , ignore.order = TRUE
                  , ignore.case = FALSE
     )
-    
+
     expect_named(object = DependencyReporter$public_fields
                  , expected = NULL
                  , info = "Available public fields for DependencyReporter not as expected."
                  , ignore.order = TRUE
                  , ignore.case = FALSE
     )
-    
+
 })
 
 ### USAGE OF PUBLIC AND PRIVATE METHODS AND FIELDS
 
 test_that('DependencyReporter Methods Work', {
     testObj <- DependencyReporter$new()
-    
+
     # inherited set_package
     expect_silent({
-        
+
         # testing set_package with a pkg_path that is relative to the current directory
         entry_wd <- getwd()
         baseball_dir <- system.file(
@@ -55,14 +55,14 @@ test_that('DependencyReporter Methods Work', {
         )
         parent_dir <- dirname(baseball_dir)
         setwd(parent_dir)
-        
+
         testObj$set_package(
             pkg_name = "baseballstats"
             , pkg_path = 'baseballstats'
         )
         setwd(entry_wd)
     })
-    
+
     # Sometimes with R CMD CHECK the temp dir begins /private/vars. Other times, just /vars.
     # Also, sometimes there are double slashes.
     fmtPath <- function(path){
@@ -71,18 +71,18 @@ test_that('DependencyReporter Methods Work', {
         out <- tools::file_path_as_absolute(out)
         return(out)
     }
-    
+
     expect_identical(
         object = fmtPath(testObj$.__enclos_env__$private$pkg_path)
         , expected = fmtPath(baseball_dir)
         , info = "set_package did not use the absolute path of the directory"
     )
-    
+
     # "extract_network"
     expect_silent({
         testObj$.__enclos_env__$private$extract_network()
     })
-    
+
     expect_named(
         object = testObj$edges
         , expected = c("SOURCE", "TARGET")
@@ -90,7 +90,7 @@ test_that('DependencyReporter Methods Work', {
         , ignore.order = FALSE # enforcing this convention
         , ignore.case = FALSE
     )
-    
+
     expect_true(object = all(testObj$edges[,unique(c(SOURCE, TARGET))] %in% c("base",
                                                                               "methods",
                                                                               "utils",
@@ -100,26 +100,25 @@ test_that('DependencyReporter Methods Work', {
                                                                               "baseballstats"))
                 , info = "unexpected package dependencies derived for baseballstats"
     )
-    
-    # TODO: Need to test that nodes were properly extracted
+
     testNodeDT <- testObj$nodes
-    
+
     expect_silent({
         testObj$pkg_graph
     })
-    
+
     expect_true({
         igraph::is_igraph(testObj$pkg_graph)
     }, info = "Graph object not an igraph formatted object")
-    
+
     expect_true({
         all(igraph::get.vertex.attribute(testObj$pkg_graph)[[1]] %in% testNodeDT$node)
     }, info = "Graph nodes not as expected")
-    
+
     expect_true({
         all(igraph::get.vertex.attribute(testObj$pkg_graph)[[1]] %in% igraph::get.vertex.attribute(testObj$pkg_graph)[[1]])
     }, info = "$pkg_graph field nodes not as expected")
-    
+
     expect_identical(
         igraph::get.edgelist(testObj$pkg_graph)
         , expected = igraph::get.edgelist(testObj$pkg_graph)

--- a/tests/testthat/test-FunctionReporter.R
+++ b/tests/testthat/test-FunctionReporter.R
@@ -90,7 +90,6 @@ test_that('FunctionReporter Methods Work', {
                  , info = "derived edges do not match expected edges"
                  )
 
-    # TODO: Need to test that nodes were properly extracted
     testNodeDT <- testObj$nodes
 
     # inherited make_graph_object
@@ -101,13 +100,6 @@ test_that('FunctionReporter Methods Work', {
 
     expect_true(object = all(igraph::get.vertex.attribute(testPkgGraph)[[1]] %in% testNodeDT$node)
                 , info = "Graph nodes not as expected")
-
-    # Nodes table with coverage and metrics too
-    # TODO: Test that calculate_all_measures and other calculates attach metadata correctly
-    # expect_identical(object = sort(testObj$get_raw_data()$nodes$node)
-    #                  , expected = sort(testNodeDT$node)
-    #                  , info = "Different nodes than expected")
-
 
     # network measures
     expect_true({


### PR DESCRIPTION
In this PR, I propose removing all TODOs from our code and turning them into issues here on Github.

I would love to add a TODO-check to our CI but I'm not sure how to do that. You can edit the `script:` block in `.travis.yml` to configure what gets run, but I'm not sure what magic is happening to ensure that `R CMD CHECK` warnings result in build failures.

So for now, I just want to remove the existing TODOs and will open a separate issue for adding a CI step to prevent new ones from getting in.