### PR TITLE
add url and DocSearch info to improve searchability of pkgnet

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Suggests:
     testthat, 
     withr
 License: BSD_3_clause + file LICENSE
-URL: https://github.com/UptakeOpenSource/pkgnet
+URL: https://github.com/UptakeOpenSource/pkgnet, https://uptakeopensource.github.io/pkgnet/
 BugReports: https://github.com/UptakeOpenSource/pkgnet/issues
 LazyData: TRUE
 RoxygenNote: 6.1.1

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,6 +2,8 @@ template:
   params:
     bootswatch: flatly
 
+url: https://uptakeopensource.github.io/pkgnet/
+
 navbar:
   title: "pkgnet"
   type: inverse
@@ -23,4 +25,3 @@ reference:
 - title: All Functions
   contents:
   - -matches("doc_shared") 
-

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,9 @@
 template:
   params:
     bootswatch: flatly
+    docsearch:
+      api_key: 8c4486b693a542e8493b7944f39ab632 # intended API inclusion.  Not private.
+      index_name: pkgnet # See https://pkgdown.r-lib.org/articles/pkgdown.html#docsearch-configuration
 
 url: https://uptakeopensource.github.io/pkgnet/
 


### PR DESCRIPTION
https://enpiar.com/2017/11/21/getting-down-with-pkgdown/
https://pkgdown.r-lib.org/reference/build_site.html#yaml-config

`url` optionally specifies the url where the site will be published. Supplying this will:
- Allow other pkgdown sites will link to your site when needed, rather than using generic links to https://rdocumentation.org.
- Generate a sitemap.xml, increasing the searchability of your site.
- Automatically generate a CNAME when deploying to github.