### PR TITLE
[ci] enforce zizmor checks, drop codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,16 @@ permissions:
   contents: none
 
 jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd #v3.0.1
   test:
     name: ${{ matrix.os }} (R ${{ matrix.r-version }})
     runs-on: ${{ matrix.os }}
@@ -67,6 +77,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     needs:
+      - lint
       - test
     permissions:
       statuses: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,16 @@ on:
     - cron: "0 0 * * 1"
   workflow_dispatch:
 
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# default to 0 permissions
+# (job-level overrides add the minimal permissions needed)
+permissions:
+  contents: none
+
 jobs:
   test:
     name: ${{ matrix.os }} (R ${{ matrix.r-version }})
@@ -21,11 +31,14 @@ jobs:
             r-version: 'release'
           - os: macos-latest
             r-version: 'release'
+    permissions:
+      contents: read
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: If local, apt update
         if: ${{ (env.ACT || false) && (matrix.os == 'ubuntu-latest')}}
         run: sudo apt update
@@ -33,30 +46,32 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt install -y tidy
       - name: set up R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
         with:
           r-version: ${{ matrix.r-version }}
-      - uses: r-lib/actions/setup-pandoc@v2
-      - uses: r-lib/actions/setup-tinytex@v2
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
+      - uses: r-lib/actions/setup-tinytex@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
+      - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
         with:
           extra-packages: any::rcmdcheck, any::covr
           needs: check
-      - uses: r-lib/actions/check-r-package@v2
+      - uses: r-lib/actions/check-r-package@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
         with:
           args: 'c("--as-cran")'
           error-on: '"warning"'
           check-dir: '"check"'
           upload-results: '"true"'
           upload-snapshots: '"true"'
-      - name: upload coverage
-        if: ${{ matrix.os == 'macos-latest' && matrix.r-version == 'release' }}
-        shell: Rscript {0}
-        run: covr::codecov(token = "${{ secrets.CODECOV_TOKEN }}")
   # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
   all-successful:
+    if: always()
     runs-on: ubuntu-latest
-    needs: [test]
+    needs:
+      - test
+    permissions:
+      statuses: read
     steps:
-    - name: Note that all tests succeeded
-      run: echo "🎉"
+      - name: Note that all tests succeeded
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# default to 0 permissions
+# default to read-only permissions
 # (job-level overrides add the minimal permissions needed)
 permissions:
-  contents: none
+  contents: read
 
 jobs:
   lint:
@@ -41,8 +41,6 @@ jobs:
             r-version: 'release'
           - os: macos-latest
             r-version: 'release'
-    permissions:
-      contents: read
     steps:
       - name: checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,28 @@ on:
         - 'release/**'
   workflow_dispatch:
 
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# default to 0 permissions
+# (job-level overrides add the minimal permissions needed)
+permissions:
+  contents: none
+
 jobs:
   version_check:
     name: Confirm Whole Version Number
     runs-on: ubuntu-latest
+    permission:
+      contents: read
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
       - name: Display Version Found
         shell: bash
         run: grep -E "Version:"  $GITHUB_WORKSPACE/DESCRIPTION
@@ -39,12 +54,15 @@ jobs:
           - os: macos-latest
             r-version: 'devel'
           - os: windows-latest
-            r-version: 'devel'   
+            r-version: 'devel'
+    permissions:
+      contents: read
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: If local, apt update
         if: ${{ (env.ACT || false) && (matrix.os == 'ubuntu-latest')}}
         run: sudo apt update
@@ -52,11 +70,11 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt install -y tidy
       - name: set up R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
         with:
           r-version: ${{ matrix.r-version }}
-      - uses: r-lib/actions/setup-pandoc@v2
-      - uses: r-lib/actions/setup-tinytex@v2
+      - uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
+      - uses: r-lib/actions/setup-tinytex@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
       - run: tlmgr --version
       - name: Install additional LaTeX Packages
         run: |
@@ -64,11 +82,11 @@ jobs:
           tlmgr update --all
           tlmgr install titling framed inconsolata
           tlmgr install collection-fontsrecommended
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
         with:
           extra-packages: any::rcmdcheck
           needs: check
-      - uses: r-lib/actions/check-r-package@v2
+      - uses: r-lib/actions/check-r-package@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
         with:
           args: 'c("--as-cran")'
           error-on: '"warning"'
@@ -76,19 +94,29 @@ jobs:
           upload-results: '"true"'
           upload-snapshots: '"true"'
   all-successful:
+    if: always()
     runs-on: ubuntu-latest
-    needs: [version_check, devel_test]
+    needs:
+      - devel_test
+      - version_check
+    permissions:
+      statuses: read
     steps:
       - name: Note that all tests succeeded
-        run: echo "🎉"
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}
   build-tarball:
     runs-on: ubuntu-latest
     needs: [version_check]
+    permissions:
+      contents: read
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: If local, apt update
         if: ${{ (env.ACT || false)}}
         run: sudo apt update
@@ -104,12 +132,9 @@ jobs:
           TAR_NAME+=".tar.gz"
           echo "TAR_NAME=$TAR_NAME" >> $GITHUB_ENV
       - name: Upload tarball to run
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{env.TAR_NAME}}
           path: ${{github.workspace}}/${{env.TAR_NAME}}
           if-no-files-found: error
           compression-level: 0 # already compressed
-
-
-  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,17 +14,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# default to 0 permissions
+# default to read-only permissions
 # (job-level overrides add the minimal permissions needed)
 permissions:
-  contents: none
+  contents: read
 
 jobs:
   version_check:
     name: Confirm Whole Version Number
     runs-on: ubuntu-latest
-    permission:
-      contents: read
     steps:
       - name: checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -10,6 +10,16 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# default to 0 permissions
+# (job-level overrides add the minimal permissions needed)
+permissions:
+  contents: none
+
 jobs:
   test:
     name: smoke-tests
@@ -74,13 +84,16 @@ jobs:
           - withr
           - xfun
           - yaml
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: set up R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
         with:
           r-version: 'release'
       - name: If local, apt update
@@ -89,7 +102,7 @@ jobs:
       - name: Install Tidy
         run: sudo apt install -y tidy 
       - name: Install Deps For Pkgnet & ${{ matrix.test_pkg }}
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
         with:
           extra-packages: ${{ matrix.test_pkg }}, local::.
       - name: run smoke test
@@ -97,8 +110,14 @@ jobs:
         run: "pkgnet::CreatePackageReport(pkg_name='${{ matrix.test_pkg }}', report_path='${{ github.workspace }}/${{ matrix.test_pkg }}_report.html')"
   # https://github.community/t/is-it-possible-to-require-all-github-actions-tasks-to-pass-without-enumerating-them/117957/4?u=graingert
   all-successful:
+    if: always()
     runs-on: ubuntu-latest
-    needs: [test]
+    needs:
+      - test
+    permissions:
+      statuses: read
     steps:
-    - name: Note that all smoke tests succeeded
-      run: echo "🚫🔥==🐻👍🏼👍🏼"
+      - name: Note that all tests succeeded
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -15,10 +15,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# default to 0 permissions
+# default to read-only permissions
 # (job-level overrides add the minimal permissions needed)
 permissions:
-  contents: none
+  contents: read
 
 jobs:
   test:
@@ -84,8 +84,6 @@ jobs:
           - withr
           - xfun
           - yaml
-    permissions:
-      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -12,17 +12,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# default to 0 permissions
+# default to read-only permissions
 # (job-level overrides add the minimal permissions needed)
 permissions:
-  contents: none
+  contents: read
 
 jobs:
   build-website:
     name: build website docs on website_docs_update branch
     runs-on: macos-latest
-    permissions:
-      contents: read
     steps:
       - name: checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -7,44 +7,61 @@ on:
       - 'v*'
   workflow_dispatch:
 
+# automatically cancel in-progress builds if another commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# default to 0 permissions
+# (job-level overrides add the minimal permissions needed)
+permissions:
+  contents: none
+
 jobs:
   build-website:
     name: build website docs on website_docs_update branch
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0 # pull all tags and other history
+          fetch-depth: 1
+          persist-credentials: false
       - name: Get Latest Version Tag
         id: previoustag
-        uses: WyriHaximus/github-action-get-previous-tag@v1.4.0
+        uses: WyriHaximus/github-action-get-previous-tag@61819f33034117e6c686e6a31dba995a85afc9de # v2.0.0
         with: 
           prefix: 'v'
       - name: Git Checkout Branch From Latest Version Tag
+        env:
+          PREVIOUS_TAG: ${{ steps.previoustag.outputs.tag }}
         run: |
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git checkout -b website_docs_update ${{steps.previoustag.outputs.tag}}
+          git checkout -b website_docs_update "${PREVIOUS_TAG}"
       - name: set up R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
         with:
           r-version: 'release'
-      - uses: r-lib/actions/setup-pandoc@v2
-      - uses: r-lib/actions/setup-tinytex@v2
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
+      - uses: r-lib/actions/setup-tinytex@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
+      - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
         with:
           packages: pkgdown
       - name: Build Site
         run: pkgdown::build_site()
         shell: Rscript {0}
       - name: Save Site Docs Articfact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: "built_website_docs_${{steps.previoustag.outputs.tag}}"
           path: ${{github.workspace}}/docs/
       - name: Commit website doc changes (overwrite if existing)
+        env:
+          PREVIOUS_TAG: ${{ steps.previoustag.outputs.tag }}
         run: |
             git add docs/\*
-            git commit -m "Update website documentation to ${{steps.previoustag.outputs.tag}}" || echo "No changes to commit"
+            git commit -m "Update website documentation to ${PREVIOUS_TAG}" || echo "No changes to commit"
             git push -f origin website_docs_update

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+---
+repos:
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: 'v1.23.1'
+    hooks:
+      - id: zizmor

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: 'v1.23.1'
+    rev: 'v1.24.1'
     hooks:
       - id: zizmor

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: 'v1.24.1'
+    rev: a4727cbbcd26d7098e96b9cb738169b59711ae51 # v1.24.1
     hooks:
       - id: zizmor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,9 @@ The code in this project should follow a standard set of conventions for style i
 
 Additional checks on code characteristics that can caught with static analysis are enforced with `pre-commit` hooks.
 
-To run those hooks locally, do the following from the root of the repo.
+Additional checks on code characteristics that can caught with static analysis are enforced with `pre-commit` hooks. We use the [pre-commit](https://pre-commit.com/) manager for installing and running those checks. You can find instructions for installing pre-commit [here](https://pre-commit.com/#install).
+
+To run the hooks locally, do the following from the root of the repo.
 
 ```shell
 pre-commit run --all-files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,14 @@ We will try to review PRs promptly and get back to you within a few days.
 
 The code in this project should follow a standard set of conventions for style in R code.
 
+Additional checks on code characteristics that can caught with static analysis are enforced with `pre-commit` hooks.
+
+To run those hooks locally, do the following from the root of the repo.
+
+```shell
+pre-commit run --all-files
+```
+
 ### Declaring Dependencies
 
 We use [roxygen2](https://github.com/klutometis/roxygen) to auto-generate our dependency lists in the package's `NAMESPACE` file. If you use a function from any package other than this package and `base`, you need to add `#' @importFrom package_name function_name` in the roxygen documentation of the function you are adding this call to.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,9 @@ We will try to review PRs promptly and get back to you within a few days.
 
 The code in this project should follow a standard set of conventions for style in R code.
 
-Additional checks on code characteristics that can caught with static analysis are enforced with `pre-commit` hooks. We use the [pre-commit](https://pre-commit.com/) manager for installing and running those checks. You can find instructions for installing pre-commit [here](https://pre-commit.com/#install).
+Additional checks on code characteristics that can be caught with static analysis are enforced with `pre-commit` hooks.
+We use the [pre-commit](https://pre-commit.com/) manager for installing and running those checks.
+You can find instructions for installing pre-commit [here](https://pre-commit.com/#install).
 
 To run the hooks locally, do the following from the root of the repo.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,8 +69,6 @@ We will try to review PRs promptly and get back to you within a few days.
 
 The code in this project should follow a standard set of conventions for style in R code.
 
-Additional checks on code characteristics that can caught with static analysis are enforced with `pre-commit` hooks.
-
 Additional checks on code characteristics that can caught with static analysis are enforced with `pre-commit` hooks. We use the [pre-commit](https://pre-commit.com/) manager for installing and running those checks. You can find instructions for installing pre-commit [here](https://pre-commit.com/#install).
 
 To run the hooks locally, do the following from the root of the repo.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![CRAN\_Download\_Badge](https://cranlogs.r-pkg.org/badges/grand-total/pkgnet)](https://cran.r-project.org/package=pkgnet) 
 [![GitHub Actions Build Status](https://github.com/uptake/pkgnet/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/uptake/pkgnet/actions/workflows/ci.yml?query=branch%3Amain)
 [![Appveyor Build status](https://ci.appveyor.com/api/projects/status/github/uptake/pkgnet?branch=main&svg=true)](https://ci.appveyor.com/project/jameslamb/pkgnet)
-[![codecov](https://codecov.io/gh/uptake/pkgnet/branch/main/graph/badge.svg)](https://app.codecov.io/gh/uptake/pkgnet) 
 [![Lifecycle badge](https://lifecycle.r-lib.org/articles/figures/lifecycle-stable.svg)](https://lifecycle.r-lib.org/articles/stages.html)
 
 ## Introduction


### PR DESCRIPTION
Proposing a couple of security-related changes:

* dropping codecov
* enforcing `zizmor` checks (GitHub Actions pinned to SHAs, protections against script injection, limiting permissions, etc.)

## Notes for Reviewers

Also proposing doing the following manual steps after this is merged:

* remove codecov integration from the repo
* set an allowlist of GitHub Actions third-party workflows