### PR TITLE
release v0.6.1

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,6 +14,7 @@
 ^CONTRIBUTING\.md$
 ^test\.sh$
 ^CODEOWNERS
+^\.pre-commit-config\.yaml$
 ^vignettes.*
 ^release_testing*
 ^CLAUDE.md$

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,18 @@ jobs:
           tlmgr update --all
           tlmgr install titling framed inconsolata
           tlmgr install collection-fontsrecommended
+      # macOS runners have no binaries for R devel, so dependencies are built
+      # from source. data.table needs gettext's libintl.h, which is absent from
+      # the CRAN toolchain prefix the compiler searches.
+      - name: Install gettext for source builds (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install gettext
+          mkdir -p ~/.R
+          {
+            echo "CPPFLAGS += -I$(brew --prefix gettext)/include"
+            echo "LDFLAGS += -L$(brew --prefix gettext)/lib -lintl"
+          } >> ~/.R/Makevars
       - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           extra-packages: any::rcmdcheck
@@ -121,7 +133,7 @@ jobs:
       - name: Install Tidy Ubuntu
         run: sudo apt install -y tidy
       - name: set up R
-        uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           r-version: 'release'
       - name: build tarball for submission to CRAN

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,10 @@ jobs:
         run: sudo apt update
       - name: Install Tidy Ubuntu
         run: sudo apt install -y tidy
+      - name: set up R
+        uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
+        with:
+          r-version: 'release'
       - name: build tarball for submission to CRAN
         run: R CMD build $GITHUB_WORKSPACE
       - name: Grab tarball path

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pkgnet
 Type: Package
 Title: Get Network Representation of an R Package
-Version: 0.6.0.9999
+Version: 0.6.1
 Authors@R: c(
     person("Brian", "Burns", email = "brian.burns.opensource@gmail.com", role = c("aut", "cre")),
     person("James", "Lamb", email = "jaylamb20@gmail.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,10 @@
-# development
+# pkgnet 0.6.1
 ## NEW FEATURES
 
 ## CHANGES
+* Removed commented-out `expect_silent` tests from the test suite. (#342)
+* CI now enforces `zizmor` checks on Github Actions workflows, and `codecov` reporting has been dropped. (#346)
+* Added `.pre-commit-config.yaml` to `.Rbuildignore` so it is excluded from the built tarball.
 
 ## BUGFIXES
 * Fixed runtime error when `FunctionReporter` extract edges from a function containing expressions of `externalptr` type. `FunctionReporter` will generally now ignore unknown expression types and instead log a warning. (#344) 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,10 @@
 # CRAN Submission History
 
+## v 0.6.1
+
+### Submission on August 12th, 2026
+This is a patch release that fixes a runtime error in `FunctionReporter` when parsing functions containing `externalptr` expressions, along with minor test suite and CI maintenance. Please see `NEWS.md` for details.
+
 ## v 0.6.0 
 
 ### Submission on January 26th, 2026


### PR DESCRIPTION
Prepare the v0.6.1 patch release for CRAN:

- Set DESCRIPTION version to 0.6.1 (drop trailing .9999)
- Convert the NEWS.md development section into the pkgnet 0.6.1 section
- Add a v0.6.1 submission entry to cran-comments.md
- Exclude .pre-commit-config.yaml from the tarball via .Rbuildignore, which otherwise produced a "hidden files and directories" NOTE under R CMD check --as-cran

R CMD check --as-cran on the 0.6.1 tarball reports Status: OK.