### PR TITLE
[ci] bump r-lib/actions pins to v2.12.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,16 +54,16 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt install -y tidy
       - name: set up R
-        uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           r-version: ${{ matrix.r-version }}
-      - uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
-      - uses: r-lib/actions/setup-tinytex@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
-      - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
+      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
+      - uses: r-lib/actions/setup-tinytex@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
+      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           extra-packages: any::rcmdcheck, any::covr
           needs: check
-      - uses: r-lib/actions/check-r-package@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
+      - uses: r-lib/actions/check-r-package@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           args: 'c("--as-cran")'
           error-on: '"warning"'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,11 +68,11 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt install -y tidy
       - name: set up R
-        uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           r-version: ${{ matrix.r-version }}
-      - uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
-      - uses: r-lib/actions/setup-tinytex@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
+      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
+      - uses: r-lib/actions/setup-tinytex@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
       - run: tlmgr --version
       - name: Install additional LaTeX Packages
         run: |
@@ -80,11 +80,11 @@ jobs:
           tlmgr update --all
           tlmgr install titling framed inconsolata
           tlmgr install collection-fontsrecommended
-      - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
+      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           extra-packages: any::rcmdcheck
           needs: check
-      - uses: r-lib/actions/check-r-package@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
+      - uses: r-lib/actions/check-r-package@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           args: 'c("--as-cran")'
           error-on: '"warning"'

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -91,7 +91,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: set up R
-        uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           r-version: 'release'
       - name: If local, apt update
@@ -100,7 +100,7 @@ jobs:
       - name: Install Tidy
         run: sudo apt install -y tidy 
       - name: Install Deps For Pkgnet & ${{ matrix.test_pkg }}
-        uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
+        uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           extra-packages: ${{ matrix.test_pkg }}, local::.
       - name: run smoke test

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -40,12 +40,12 @@ jobs:
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git checkout -b website_docs_update "${PREVIOUS_TAG}"
       - name: set up R
-        uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           r-version: 'release'
-      - uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
-      - uses: r-lib/actions/setup-tinytex@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
-      - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2.11.4
+      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
+      - uses: r-lib/actions/setup-tinytex@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
+      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2.12.1
         with:
           packages: pkgdown
       - name: Build Site


### PR DESCRIPTION
GitHub Actions runners are deprecating Node.js 20, and every run warns that setup-r, setup-pandoc, setup-tinytex, and actions/cache@v4 are being force-run on Node 24.

r-lib/actions v2.12.0 moved all its node actions to node24 and setup-r-dependencies now pins actions/cache v5.0.5 internally, so this single bump clears all four warnings. actions/cache is not referenced directly by this repo; it comes in transitively via setup-r-dependencies.

Every other pinned action in these workflows was checked and is already on node24 or is a composite action: actions/checkout, actions/upload- artifact, WyriHaximus/github-action-get-previous-tag, re-actors/alls- green, and pre-commit/action.

Behavior change to watch from v2.12.0: setup-r now defaults to
use-public-rspm: true on Linux and Windows.